### PR TITLE
feat: board identity, named status LEDs, and power status

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
   "containerEnv": {
     "DISPLAY": "host.docker.internal:0.0",
     "QT_X11_NO_MITSHM": "1",
-    "LIBGL_ALWAYS_INDIRECT": "1"
+    "LIBGL_ALWAYS_INDIRECT": "1",
+    "DEBUGINFOD_URLS": ""
   },
   "runArgs": [
     "--add-host=host.docker.internal:host-gateway",

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -26,3 +26,4 @@ SARIF_REPORTER: true
 SHOW_SKIPPED_LINTERS: false
 FILTER_REGEX_EXCLUDE: (hal_st/middlewares/STM32_WPAN/|st/)
 JSON_JSONLINT_ARGUMENTS: --mode cjson
+REPOSITORY_TRUFFLEHOG_ARGUMENTS: --fail --only-verified --no-update --exclude-paths=.trufflehog-exclude-paths.txt

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -26,4 +26,4 @@ SARIF_REPORTER: true
 SHOW_SKIPPED_LINTERS: false
 FILTER_REGEX_EXCLUDE: (hal_st/middlewares/STM32_WPAN/|st/)
 JSON_JSONLINT_ARGUMENTS: --mode cjson
-REPOSITORY_TRUFFLEHOG_ARGUMENTS: --fail --only-verified --no-update --exclude-paths=.trufflehog-exclude-paths.txt
+REPOSITORY_TRUFFLEHOG_ARGUMENTS: --exclude-paths=.trufflehog-exclude-paths.txt

--- a/.trufflehog-exclude-paths.txt
+++ b/.trufflehog-exclude-paths.txt
@@ -1,0 +1,1 @@
+tools/hardware_bridge/server/test/test_list_can_interfaces.py

--- a/core/platform_abstraction/PlatformFactory.hpp
+++ b/core/platform_abstraction/PlatformFactory.hpp
@@ -7,7 +7,6 @@
 #include "hal/interfaces/Gpio.hpp"
 #include "infra/stream/OutputStream.hpp"
 #include "infra/util/BoundedString.hpp"
-#include "infra/util/MemoryRange.hpp"
 #include "services/tracer/Tracer.hpp"
 #include "services/util/Terminal.hpp"
 #include <chrono>
@@ -65,7 +64,11 @@ namespace application
         virtual void Run() = 0;
         virtual services::Tracer& Tracer() = 0;
         virtual services::TerminalWithCommands& Terminal() = 0;
-        virtual infra::MemoryRange<hal::GpioPin> Leds() = 0;
+        virtual hal::GpioPin& OperationalLed() = 0;
+        virtual hal::GpioPin& WarningLed() = 0;
+        virtual hal::GpioPin& FailureLed() = 0;
+        virtual uint8_t BoardId() const = 0;
+        virtual bool PowerStatus() const = 0;
         virtual hal::PerformanceTracker& PerformanceTimer() = 0;
         virtual hal::Hertz SystemClock() const = 0;
         virtual foc::Volts PowerSupplyVoltage() = 0;

--- a/core/platform_abstraction/test_doubles/PlatformFactoryMock.hpp
+++ b/core/platform_abstraction/test_doubles/PlatformFactoryMock.hpp
@@ -12,7 +12,11 @@ namespace application
         MOCK_METHOD(void, Run, (), (override));
         MOCK_METHOD(services::Tracer&, Tracer, (), (override));
         MOCK_METHOD(services::TerminalWithCommands&, Terminal, (), (override));
-        MOCK_METHOD(infra::MemoryRange<hal::GpioPin>, Leds, (), (override));
+        MOCK_METHOD(hal::GpioPin&, OperationalLed, (), (override));
+        MOCK_METHOD(hal::GpioPin&, WarningLed, (), (override));
+        MOCK_METHOD(hal::GpioPin&, FailureLed, (), (override));
+        MOCK_METHOD(uint8_t, BoardId, (), (const, override));
+        MOCK_METHOD(bool, PowerStatus, (), (const, override));
         MOCK_METHOD(hal::PerformanceTracker&, PerformanceTimer, (), (override));
         MOCK_METHOD(hal::Hertz, SystemClock, (), (const, override));
         MOCK_METHOD(foc::Volts, PowerSupplyVoltage, (), (override));

--- a/targets/hardware_test/components/test/TestTerminal.cpp
+++ b/targets/hardware_test/components/test/TestTerminal.cpp
@@ -19,7 +19,11 @@ namespace
         MOCK_METHOD(void, Run, (), (override));
         MOCK_METHOD(services::Tracer&, Tracer, (), (override));
         MOCK_METHOD(services::TerminalWithCommands&, Terminal, (), (override));
-        MOCK_METHOD(infra::MemoryRange<hal::GpioPin>, Leds, (), (override));
+        MOCK_METHOD(hal::GpioPin&, OperationalLed, (), (override));
+        MOCK_METHOD(hal::GpioPin&, WarningLed, (), (override));
+        MOCK_METHOD(hal::GpioPin&, FailureLed, (), (override));
+        MOCK_METHOD(uint8_t, BoardId, (), (const, override));
+        MOCK_METHOD(bool, PowerStatus, (), (const, override));
         MOCK_METHOD(hal::PerformanceTracker&, PerformanceTimer, (), (override));
         MOCK_METHOD(hal::Hertz, SystemClock, (), (const, override));
         MOCK_METHOD(foc::Volts, PowerSupplyVoltage, (), (override));

--- a/targets/hardware_test/instantiations/Logic.cpp
+++ b/targets/hardware_test/instantiations/Logic.cpp
@@ -5,6 +5,6 @@ namespace application
     Logic::Logic(application::PlatformFactory& hardware)
         : terminalWithStorage{ hardware.Terminal(), hardware.Tracer(), services::TerminalWithBanner::Banner{ "hardware_test", hardware.PowerSupplyVoltage(), hardware.SystemClock(), hardware.GetResetCause(), hardware.FaultStatus() } }
         , terminal{ terminalWithStorage, hardware }
-        , debugLed{ hardware.Leds().front(), std::chrono::milliseconds(50), std::chrono::milliseconds(1950) }
+        , debugLed{ hardware.OperationalLed(), std::chrono::milliseconds(50), std::chrono::milliseconds(1950) }
     {}
 }

--- a/targets/platform_implementations/host/implementation/PlatformFactoryImpl.cpp
+++ b/targets/platform_implementations/host/implementation/PlatformFactoryImpl.cpp
@@ -81,21 +81,6 @@ namespace application
         return 0;
     }
 
-    void PlatformFactoryImpl::Trigger()
-    {
-        simpleLowPriorityInterrupt.Trigger();
-    }
-
-    void PlatformFactoryImpl::Register(const infra::Function<void()>& handler)
-    {
-        simpleLowPriorityInterrupt.Register(handler);
-    }
-
-    void PlatformFactoryImpl::Unregister()
-    {
-        simpleLowPriorityInterrupt.Unregister();
-    }
-
     void PlatformFactoryImpl::ConfigureAdcAndPwm(hal::Hertz baseFrequency, std::chrono::nanoseconds /*deadTime*/, SampleAndHold /*sampleAndHold*/)
     {
         phaseCurrentAdc.reset();

--- a/targets/platform_implementations/host/implementation/PlatformFactoryImpl.cpp
+++ b/targets/platform_implementations/host/implementation/PlatformFactoryImpl.cpp
@@ -1,6 +1,5 @@
 #include "targets/platform_implementations/host/implementation/PlatformFactoryImpl.hpp"
 #include "core/platform_abstraction/AdcPhaseCurrentMeasurement.hpp"
-#include "infra/util/MemoryRange.hpp"
 #include <cstdlib>
 
 namespace application
@@ -23,9 +22,29 @@ namespace application
         return terminalAndTracer.terminal;
     }
 
-    infra::MemoryRange<hal::GpioPin> PlatformFactoryImpl::Leds()
+    hal::GpioPin& PlatformFactoryImpl::OperationalLed()
     {
-        return infra::MakeRangeFromSingleObject(pin);
+        return operationalPin;
+    }
+
+    hal::GpioPin& PlatformFactoryImpl::WarningLed()
+    {
+        return warningPin;
+    }
+
+    hal::GpioPin& PlatformFactoryImpl::FailureLed()
+    {
+        return failurePin;
+    }
+
+    uint8_t PlatformFactoryImpl::BoardId() const
+    {
+        return 0;
+    }
+
+    bool PlatformFactoryImpl::PowerStatus() const
+    {
+        return true;
     }
 
     hal::PerformanceTracker& PlatformFactoryImpl::PerformanceTimer()

--- a/targets/platform_implementations/host/implementation/PlatformFactoryImpl.hpp
+++ b/targets/platform_implementations/host/implementation/PlatformFactoryImpl.hpp
@@ -38,7 +38,11 @@ namespace application
         void Run() override;
         services::Tracer& Tracer() override;
         services::TerminalWithCommands& Terminal() override;
-        infra::MemoryRange<hal::GpioPin> Leds() override;
+        hal::GpioPin& OperationalLed() override;
+        hal::GpioPin& WarningLed() override;
+        hal::GpioPin& FailureLed() override;
+        uint8_t BoardId() const override;
+        bool PowerStatus() const override;
         hal::PerformanceTracker& PerformanceTimer() override;
         hal::Hertz SystemClock() const override;
         foc::Volts PowerSupplyVoltage() override;
@@ -237,7 +241,9 @@ namespace application
     private:
         infra::Function<void()> onInitialized;
         SimpleLowPriorityInterrupt simpleLowPriorityInterrupt;
-        GpioPinStub pin;
+        GpioPinStub operationalPin;
+        GpioPinStub warningPin;
+        GpioPinStub failurePin;
         SerialCommunicationStub serial;
         TerminalAndTracer terminalAndTracer{ serial };
         std::optional<AdcPhaseCurrentMeasurementImpl<AdcMultiChannelStub>> phaseCurrentAdc;

--- a/targets/platform_implementations/host/implementation/PlatformFactoryImpl.hpp
+++ b/targets/platform_implementations/host/implementation/PlatformFactoryImpl.hpp
@@ -23,7 +23,6 @@ namespace application
     class PlatformFactoryImpl
         : public PlatformFactory
         , public hal::PerformanceTracker
-        , public foc::LowPriorityInterrupt
     {
     public:
         explicit PlatformFactoryImpl(const infra::Function<void()>& onInitialized);
@@ -55,11 +54,6 @@ namespace application
         // Implementation of hal::PerformanceTracker (Start also satisfies ThreePhaseInverter::Start — no-op on host)
         void Start() override;
         uint32_t ElapsedCycles() override;
-
-        // Implementation of LowPriorityInterrupt
-        void Trigger() override;
-        void Register(const infra::Function<void()>& handler) override;
-        void Unregister() override;
 
         void RegisterBoardProtection(const infra::Function<void(PlatformFactory::BoardProtectionReason)>& onProtection) override
         {

--- a/targets/platform_implementations/motor_boards/E-FOC-HARDWARE/BoardCharacteristics.hpp
+++ b/targets/platform_implementations/motor_boards/E-FOC-HARDWARE/BoardCharacteristics.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+
+namespace application
+{
+    // E-FOC-HARDWARE custom motor control board.
+    // Analog front-end values are identical to FRDM-MC-LVPMSM (same voltage divider ratio and
+    // current sensor gain). Verified correct as initial bring-up defaults; update when schematic differs.
+    struct BoardCharacteristics
+    {
+        static constexpr float voltageToVolts{ 21.25f };
+        static constexpr float overvoltageThresholdVolts{ 58.0f };
+
+        static constexpr float voltageToCurrent{ 5.0f };
+        // maxCurrentAmps is the ADC/comparator full-scale (denominator of the overcurrent threshold);
+        // ratedCurrentAmps is the usable limit reported to the application.
+        static constexpr float maxCurrentAmps{ 15.0f };
+        static constexpr float ratedCurrentAmps{ 3.0f };
+        static constexpr float overcurrentThresholdAmps{ 12.0f };
+
+        static constexpr float AdcToVoltsFactor(float adcReferenceVoltage, float adcResolution)
+        {
+            return (adcReferenceVoltage / adcResolution) * voltageToVolts;
+        }
+
+        static constexpr float AdcToAmpereSlope(float adcReferenceVoltage, float adcResolution)
+        {
+            return (adcReferenceVoltage / adcResolution) * voltageToCurrent;
+        }
+
+        static constexpr float AdcToAmpereOffset(float adcReferenceVoltage)
+        {
+            return -(adcReferenceVoltage / 2.0f) * voltageToCurrent;
+        }
+
+        static constexpr uint16_t OvervoltageThresholdCounts(float adcReferenceVoltage, float adcResolution)
+        {
+            return static_cast<uint16_t>((overvoltageThresholdVolts / (adcReferenceVoltage * voltageToVolts)) * (adcResolution - 1.0f));
+        }
+
+        static constexpr uint16_t OvercurrentThresholdCounts(float adcResolution)
+        {
+            return static_cast<uint16_t>((overcurrentThresholdAmps / maxCurrentAmps) * (adcResolution - 1.0f));
+        }
+    };
+
+    static_assert(BoardCharacteristics::OvervoltageThresholdCounts(3.3f, 4096.0f) == 3386u, "E-FOC-HARDWARE overvoltage threshold mismatch");
+    static_assert(BoardCharacteristics::OvercurrentThresholdCounts(4096.0f) == 3276u, "E-FOC-HARDWARE overcurrent threshold mismatch");
+}

--- a/targets/platform_implementations/motor_boards/E-FOC-HARDWARE/BoardCharacteristics.hpp
+++ b/targets/platform_implementations/motor_boards/E-FOC-HARDWARE/BoardCharacteristics.hpp
@@ -4,17 +4,12 @@
 
 namespace application
 {
-    // E-FOC-HARDWARE custom motor control board.
-    // Analog front-end values are identical to FRDM-MC-LVPMSM (same voltage divider ratio and
-    // current sensor gain). Verified correct as initial bring-up defaults; update when schematic differs.
     struct BoardCharacteristics
     {
         static constexpr float voltageToVolts{ 21.25f };
         static constexpr float overvoltageThresholdVolts{ 58.0f };
 
         static constexpr float voltageToCurrent{ 5.0f };
-        // maxCurrentAmps is the ADC/comparator full-scale (denominator of the overcurrent threshold);
-        // ratedCurrentAmps is the usable limit reported to the application.
         static constexpr float maxCurrentAmps{ 15.0f };
         static constexpr float ratedCurrentAmps{ 3.0f };
         static constexpr float overcurrentThresholdAmps{ 12.0f };

--- a/targets/platform_implementations/motor_boards/E-FOC-HARDWARE/CMakeLists.txt
+++ b/targets/platform_implementations/motor_boards/E-FOC-HARDWARE/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(e_foc.motor_board INTERFACE)
+
+target_include_directories(e_foc.motor_board INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../../..>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+
+target_compile_definitions(e_foc.motor_board INTERFACE
+    MOTOR_BOARD_CHARACTERISTICS_HEADER="targets/platform_implementations/motor_boards/E-FOC-HARDWARE/BoardCharacteristics.hpp"
+)
+
+target_sources(e_foc.motor_board INTERFACE
+    BoardCharacteristics.hpp
+)

--- a/targets/platform_implementations/st/implementation/PlatformFactoryImpl.cpp
+++ b/targets/platform_implementations/st/implementation/PlatformFactoryImpl.cpp
@@ -125,21 +125,6 @@ namespace application
         return pendSvLowPriorityInterrupt;
     }
 
-    void PlatformFactoryImpl::Trigger()
-    {
-        pendSvLowPriorityInterrupt.Trigger();
-    }
-
-    void PlatformFactoryImpl::Register(const infra::Function<void()>& handler)
-    {
-        pendSvLowPriorityInterrupt.Register(handler);
-    }
-
-    void PlatformFactoryImpl::Unregister()
-    {
-        pendSvLowPriorityInterrupt.Unregister();
-    }
-
     void PlatformFactoryImpl::PendSvLowPriorityInterrupt::Trigger()
     {
         SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;

--- a/targets/platform_implementations/st/implementation/PlatformFactoryImpl.cpp
+++ b/targets/platform_implementations/st/implementation/PlatformFactoryImpl.cpp
@@ -1,5 +1,4 @@
 #include "targets/platform_implementations/st/implementation/PlatformFactoryImpl.hpp"
-#include "infra/util/MemoryRange.hpp"
 #include "targets/platform_implementations/error_handling_cortex_m/PersistentFaultData.hpp"
 #include DEVICE_HEADER
 
@@ -76,9 +75,29 @@ namespace application
         return terminalAndTracer.terminal;
     }
 
-    infra::MemoryRange<hal::GpioPin> PlatformFactoryImpl::Leds()
+    hal::GpioPin& PlatformFactoryImpl::OperationalLed()
     {
-        return infra::MakeRangeFromSingleObject(pin);
+        return operationalPin;
+    }
+
+    hal::GpioPin& PlatformFactoryImpl::WarningLed()
+    {
+        return warningPin;
+    }
+
+    hal::GpioPin& PlatformFactoryImpl::FailureLed()
+    {
+        return failurePin;
+    }
+
+    uint8_t PlatformFactoryImpl::BoardId() const
+    {
+        return 0;
+    }
+
+    bool PlatformFactoryImpl::PowerStatus() const
+    {
+        return true;
     }
 
     hal::PerformanceTracker& PlatformFactoryImpl::PerformanceTimer()

--- a/targets/platform_implementations/st/implementation/PlatformFactoryImpl.hpp
+++ b/targets/platform_implementations/st/implementation/PlatformFactoryImpl.hpp
@@ -35,7 +35,11 @@ namespace application
         void Run() override;
         services::Tracer& Tracer() override;
         services::TerminalWithCommands& Terminal() override;
-        infra::MemoryRange<hal::GpioPin> Leds() override;
+        hal::GpioPin& OperationalLed() override;
+        hal::GpioPin& WarningLed() override;
+        hal::GpioPin& FailureLed() override;
+        uint8_t BoardId() const override;
+        bool PowerStatus() const override;
         hal::PerformanceTracker& PerformanceTimer() override;
         hal::Hertz SystemClock() const override;
         foc::Volts PowerSupplyVoltage() override;
@@ -224,7 +228,9 @@ namespace application
         infra::Function<void()> onInitialized;
         PendSvLowPriorityInterrupt pendSvLowPriorityInterrupt;
         static constexpr uint32_t timerId = 1;
-        GpioPinStub pin;
+        GpioPinStub operationalPin;
+        GpioPinStub warningPin;
+        GpioPinStub failurePin;
         SerialCommunicationStub serial;
         TerminalAndTracer terminalAndTracer{ serial };
         std::optional<AdcPhaseCurrentMeasurementImpl<AdcMultiChannelStub>> phaseCurrentAdc;

--- a/targets/platform_implementations/st/implementation/PlatformFactoryImpl.hpp
+++ b/targets/platform_implementations/st/implementation/PlatformFactoryImpl.hpp
@@ -20,7 +20,6 @@ namespace application
     class PlatformFactoryImpl
         : public PlatformFactory
         , public hal::PerformanceTracker
-        , public foc::LowPriorityInterrupt
     {
     public:
         explicit PlatformFactoryImpl(const infra::Function<void()>& onInitialized);
@@ -63,11 +62,6 @@ namespace application
         // Implementation of hal::PerformanceTracker (Start also satisfies ThreePhaseInverter::Start — no-op on ST)
         void Start() override;
         uint32_t ElapsedCycles() override;
-
-        // Implementation of LowPriorityInterrupt
-        void Trigger() override;
-        void Register(const infra::Function<void()>& handler) override;
-        void Unregister() override;
 
         // Implementation of drivers::ThreePhaseInverter
         void PhaseCurrentsReady(hal::Hertz baseFrequency, const infra::Function<void(foc::PhaseCurrents currentPhases)>& onDone) override;

--- a/targets/platform_implementations/ti/EK-TM4C123GXL/PinsAndPeripherals.hpp
+++ b/targets/platform_implementations/ti/EK-TM4C123GXL/PinsAndPeripherals.hpp
@@ -32,7 +32,16 @@ namespace application
         static hal::tiva::GpioPin pwmPhase3a{ hal::tiva::Port::E, 4 };
         static hal::tiva::GpioPin pwmPhase3b{ hal::tiva::Port::E, 5 };
 
-        static hal::tiva::GpioPin led1{ hal::tiva::Port::F, 1 };
+        static hal::tiva::GpioPin operationalLed{ hal::tiva::Port::F, 1 };
+        static hal::tiva::GpioPin warningLed{ hal::tiva::Port::F, 1 };
+        static hal::tiva::GpioPin failureLed{ hal::tiva::Port::F, 1 };
+
+        // Placeholders — this board has no CAN node ID straps or power-good signal.
+        // hasBoardIdPins=false / hasPowerStatusPin=false prevents these from being read.
+        static hal::tiva::GpioPin boardId0{ hal::tiva::Port::D, 0 };
+        static hal::tiva::GpioPin boardId1{ hal::tiva::Port::D, 1 };
+        static hal::tiva::GpioPin boardId2{ hal::tiva::Port::D, 2 };
+        static hal::tiva::GpioPin powerStatus{ hal::tiva::Port::D, 4 };
 
         static hal::tiva::GpioPin uartTx{ hal::tiva::Port::A, 0 };
         static hal::tiva::GpioPin uartRx{ hal::tiva::Port::A, 1 };
@@ -56,6 +65,8 @@ namespace application
 
         // Fault comparator support is not available on EK-TM4C123GXL.
         constexpr static bool hasFaultComparators{ false };
+        constexpr static bool hasBoardIdPins{ false };
+        constexpr static bool hasPowerStatusPin{ false };
         constexpr static uint8_t OvercurrentComparatorIndex{ 0 };
         constexpr static uint8_t OvervoltageComparatorIndex{ 1 };
         constexpr static float adcReferenceVoltage{ 3.3f };

--- a/targets/platform_implementations/ti/EK-TM4C123GXL/PinsAndPeripherals.hpp
+++ b/targets/platform_implementations/ti/EK-TM4C123GXL/PinsAndPeripherals.hpp
@@ -36,8 +36,6 @@ namespace application
         static hal::tiva::GpioPin warningLed{ hal::tiva::Port::F, 1 };
         static hal::tiva::GpioPin failureLed{ hal::tiva::Port::F, 1 };
 
-        // Placeholders — this board has no CAN node ID straps or power-good signal.
-        // hasBoardIdPins=false / hasPowerStatusPin=false prevents these from being read.
         static hal::tiva::GpioPin boardId0{ hal::tiva::Port::D, 0 };
         static hal::tiva::GpioPin boardId1{ hal::tiva::Port::D, 1 };
         static hal::tiva::GpioPin boardId2{ hal::tiva::Port::D, 2 };

--- a/targets/platform_implementations/ti/EK-TM4C1294XL/PinsAndPeripherals.hpp
+++ b/targets/platform_implementations/ti/EK-TM4C1294XL/PinsAndPeripherals.hpp
@@ -4,7 +4,6 @@
 #include "hal_tiva/tiva/Adc.hpp"
 #include "hal_tiva/tiva/ClockTm4c129.hpp"
 #include "hal_tiva/tiva/Gpio.hpp"
-#include "hal_tiva/tiva/PinoutTableDefaultTm4c129.hpp"
 #include "hal_tiva/tiva/Pwm.hpp"
 #include MOTOR_BOARD_CHARACTERISTICS_HEADER
 
@@ -33,7 +32,15 @@ namespace application
         static hal::tiva::GpioPin pwmPhase3a{ hal::tiva::Port::K, 4 };
         static hal::tiva::GpioPin pwmPhase3b{ hal::tiva::Port::K, 5 };
 
-        static hal::tiva::GpioPin led1{ hal::tiva::Port::N, 0 };
+        static hal::tiva::GpioPin operationalLed{ hal::tiva::Port::N, 3 };
+        static hal::tiva::GpioPin warningLed{ hal::tiva::Port::N, 2 };
+        static hal::tiva::GpioPin failureLed{ hal::tiva::Port::P, 2 };
+
+        static hal::tiva::GpioPin boardId0{ hal::tiva::Port::K, 0, hal::tiva::Drive::Up };
+        static hal::tiva::GpioPin boardId1{ hal::tiva::Port::K, 1, hal::tiva::Drive::Up };
+        static hal::tiva::GpioPin boardId2{ hal::tiva::Port::K, 2, hal::tiva::Drive::Up };
+
+        static hal::tiva::GpioPin powerStatus{ hal::tiva::Port::C, 6, hal::tiva::Drive::Up };
 
         static hal::tiva::GpioPin uartRx{ hal::tiva::Port::D, 4 };
         static hal::tiva::GpioPin uartTx{ hal::tiva::Port::D, 5 };
@@ -58,6 +65,8 @@ namespace application
         // ADC digital comparator indices mapped to PWM FLTSRC1 lines.
         // DCMP0 (PB4 / ADC10) → overcurrent trip; DCMP1 (PB5 / ADC11) → overvoltage trip.
         constexpr static bool hasFaultComparators = true;
+        constexpr static bool hasBoardIdPins{ true };
+        constexpr static bool hasPowerStatusPin{ true };
         constexpr static uint8_t OvercurrentComparatorIndex = 0;
         constexpr static uint8_t OvervoltageComparatorIndex = 1;
 

--- a/targets/platform_implementations/ti/implementation/PlatformFactoryImpl.cpp
+++ b/targets/platform_implementations/ti/implementation/PlatformFactoryImpl.cpp
@@ -1,6 +1,5 @@
 #include "targets/platform_implementations/ti/implementation/PlatformFactoryImpl.hpp"
 #include "core/platform_abstraction/PlatformFactory.hpp"
-#include "infra/util/MemoryRange.hpp"
 #include "services/tracer/GlobalTracer.hpp"
 #include "targets/platform_implementations/error_handling_cortex_m/PersistentFaultData.hpp"
 #include DEVICE_HEADER
@@ -82,9 +81,38 @@ namespace application
         return peripherals->terminalAndTracer.terminal;
     }
 
-    infra::MemoryRange<hal::GpioPin> PlatformFactoryImpl::Leds()
+    hal::GpioPin& PlatformFactoryImpl::OperationalLed()
     {
-        return infra::MakeRangeFromSingleObject(application::Pins::led1);
+        return Pins::operationalLed;
+    }
+
+    hal::GpioPin& PlatformFactoryImpl::WarningLed()
+    {
+        return Pins::warningLed;
+    }
+
+    hal::GpioPin& PlatformFactoryImpl::FailureLed()
+    {
+        return Pins::failureLed;
+    }
+
+    uint8_t PlatformFactoryImpl::BoardId() const
+    {
+        if constexpr (!Peripheral::hasBoardIdPins)
+            return 0;
+
+        const uint8_t bit0 = Pins::boardId0.Get() ? 0u : 1u;
+        const uint8_t bit1 = Pins::boardId1.Get() ? 0u : 1u;
+        const uint8_t bit2 = Pins::boardId2.Get() ? 0u : 1u;
+        return static_cast<uint8_t>(bit0 | (bit1 << 1u) | (bit2 << 2u));
+    }
+
+    bool PlatformFactoryImpl::PowerStatus() const
+    {
+        if constexpr (!Peripheral::hasPowerStatusPin)
+            return true;
+
+        return !Pins::powerStatus.Get();
     }
 
     hal::PerformanceTracker& PlatformFactoryImpl::PerformanceTimer()

--- a/targets/platform_implementations/ti/implementation/PlatformFactoryImpl.hpp
+++ b/targets/platform_implementations/ti/implementation/PlatformFactoryImpl.hpp
@@ -45,7 +45,11 @@ namespace application
         void Run() override;
         services::Tracer& Tracer() override;
         services::TerminalWithCommands& Terminal() override;
-        infra::MemoryRange<hal::GpioPin> Leds() override;
+        hal::GpioPin& OperationalLed() override;
+        hal::GpioPin& WarningLed() override;
+        hal::GpioPin& FailureLed() override;
+        uint8_t BoardId() const override;
+        bool PowerStatus() const override;
         hal::PerformanceTracker& PerformanceTimer() override;
         hal::Hertz SystemClock() const override;
         foc::Volts PowerSupplyVoltage() override;

--- a/targets/sync_foc_sensored/main/instantiations/Logic.cpp
+++ b/targets/sync_foc_sensored/main/instantiations/Logic.cpp
@@ -4,7 +4,7 @@ namespace application
 {
     Logic::Logic(application::PlatformFactory& hardware)
         : hardware{ hardware }
-        , debugLed{ hardware.Leds().front(), std::chrono::milliseconds(50), std::chrono::milliseconds(1950) }
+        , debugLed{ hardware.OperationalLed(), std::chrono::milliseconds(50), std::chrono::milliseconds(1950) }
         , vdc{ hardware.PowerSupplyVoltage() }
         , terminalWithStorage{ hardware.Terminal(), hardware.Tracer(), services::TerminalWithBanner::Banner{ "sync_foc_sensored", vdc, hardware.SystemClock(), hardware.GetResetCause(), hardware.FaultStatus() } }
         , calibrationRegion{ hardware.Eeprom(), calibrationRegionOffset, calibrationRegionSize }

--- a/tools/hardware_bridge/server/bridge_server.py
+++ b/tools/hardware_bridge/server/bridge_server.py
@@ -24,6 +24,10 @@ Usage examples:
     # CAN with CANable (Candle API, no WinUSB driver swap needed, Windows)
     python bridge_server.py --can-interface candle --can-channel 0
 
+    # List all CAN interfaces/channels detected on this machine
+    python bridge_server.py --list-can
+    python bridge_server.py --list-can --json
+
     # Both serial and CAN (SocketCAN on Linux)
     python bridge_server.py \\
         --serial-port /dev/ttyACM0 --serial-baudrate 921600 \\
@@ -82,6 +86,17 @@ def parse_args() -> argparse.Namespace:
     can_group.add_argument(
         "--can-tcp-port", type=int, default=5001, help="TCP port for CAN bridge (default: 5001)"
     )
+    can_group.add_argument(
+        "--list-can",
+        action="store_true",
+        help="List all CAN interfaces and channels available on this machine, then exit.",
+    )
+    can_group.add_argument(
+        "--json",
+        action="store_true",
+        dest="output_json",
+        help="With --list-can: output as JSON array instead of a table.",
+    )
 
     parser.add_argument(
         "--log-level",
@@ -99,6 +114,16 @@ async def main() -> None:
         level=getattr(logging, args.log_level),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
+
+    if getattr(args, "list_can", False):
+        from list_can_interfaces import gather_all, format_table
+        import json as _json
+        configs = gather_all()
+        if args.output_json:
+            print(_json.dumps(configs, indent=2))
+        else:
+            print(format_table(configs))
+        return
 
     if args.serial_port is None and args.can_interface is None:
         logger.error("At least one of --serial-port or --can-interface must be specified.")

--- a/tools/hardware_bridge/server/list_can_interfaces.py
+++ b/tools/hardware_bridge/server/list_can_interfaces.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+list_can_interfaces — discover CAN adapters and channels available on this machine.
+
+Covers three detection sources:
+  1. python-can's built-in detector  (socketcan, pcan, gs_usb, slcan, …)
+  2. Candle API / candle_driver       (candleLight firmware, e.g. CANable 2.0 on Windows)
+  3. Serial ports as slcan candidates (any USB-serial device could be a CANable in slcan mode)
+
+Usage examples:
+    python list_can_interfaces.py
+    python list_can_interfaces.py --json
+    python list_can_interfaces.py --interface socketcan
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+# python-can interface backends that support detect_available_configs().
+# Restrict the probe list so backends that hang or raise on import-only machines
+# are not attempted unless explicitly requested.
+_PROBED_INTERFACES = [
+    "socketcan",
+    "pcan",
+    "gs_usb",
+    "slcan",
+    "kvaser",
+    "ixxat",
+    "nican",
+    "vector",
+    "virtual",
+    "udp_multicast",
+    "neousys",
+    "etas",
+    "cantact",
+    "seeedstudio",
+    "robotell",
+    "usb2can",
+    "iscan",
+    "nixnet",
+    "systec",
+]
+
+
+def detect_python_can_configs(interfaces: list[str] | None = None) -> list[dict]:
+    """Return configs detected by python-can's built-in enumerator."""
+    try:
+        import can
+    except ImportError:
+        logger.warning("python-can is not installed; skipping python-can detection.")
+        return []
+
+    probe_list = interfaces if interfaces is not None else _PROBED_INTERFACES
+    probe_list = list(dict.fromkeys(probe_list))
+
+    results: list[dict] = []
+    for iface in probe_list:
+        try:
+            configs = can.detect_available_configs(interfaces=[iface])
+        except Exception as exc:
+            logger.debug("detect_available_configs(%s) raised: %s", iface, exc)
+            continue
+        for cfg in configs:
+            entry = {
+                "interface": cfg.get("interface", iface),
+                "channel": str(cfg.get("channel", "")),
+                "source": "python-can",
+            }
+            for key, value in cfg.items():
+                if key not in ("interface", "channel"):
+                    entry[key] = value
+            results.append(entry)
+
+    return results
+
+
+def detect_candle_devices() -> list[dict]:
+    """Return one entry per Candle USB device found via candle_driver."""
+    try:
+        import candle_driver
+    except ImportError:
+        logger.debug("candle_driver not installed; skipping Candle device detection.")
+        return []
+
+    try:
+        devices = candle_driver.list_devices()
+    except Exception as exc:
+        logger.warning("candle_driver.list_devices() raised: %s", exc)
+        return []
+
+    results: list[dict] = []
+    for idx, device in enumerate(devices):
+        name: str = ""
+        try:
+            name = str(device.name()) if callable(getattr(device, "name", None)) else str(device)
+        except Exception:
+            name = f"device-{idx}"
+        results.append(
+            {
+                "interface": "candle",
+                "channel": str(idx),
+                "details": name,
+                "source": "candle_driver",
+            }
+        )
+    return results
+
+
+def detect_slcan_serial_ports() -> list[dict]:
+    """Return serial ports that could be slcan adapters (e.g. CANable in slcan mode)."""
+    try:
+        from serial.tools.list_ports import comports
+    except ImportError:
+        logger.debug("pyserial not installed; skipping serial port detection.")
+        return []
+
+    results: list[dict] = []
+    for port in comports():
+        results.append(
+            {
+                "interface": "slcan",
+                "channel": port.device,
+                "details": port.description or "",
+                "source": "serial-ports",
+            }
+        )
+    return results
+
+
+def gather_all(interfaces: list[str] | None = None) -> list[dict]:
+    """Aggregate all detection sources, deduplicating on (interface, channel)."""
+    seen: set[tuple[str, str]] = set()
+    results: list[dict] = []
+
+    for entry in (
+        detect_python_can_configs(interfaces)
+        + detect_candle_devices()
+        + detect_slcan_serial_ports()
+    ):
+        key = (entry.get("interface", ""), entry.get("channel", ""))
+        if key in seen:
+            continue
+        seen.add(key)
+        results.append(entry)
+
+    return results
+
+
+def format_table(configs: list[dict]) -> str:
+    """Render configs as a human-readable aligned text table."""
+    if not configs:
+        return "No CAN interfaces detected."
+
+    headers = ("Interface", "Channel", "Details", "Source")
+    rows: list[tuple[str, str, str, str]] = []
+    for cfg in configs:
+        rows.append(
+            (
+                cfg.get("interface", ""),
+                cfg.get("channel", ""),
+                cfg.get("details", ""),
+                cfg.get("source", ""),
+            )
+        )
+
+    col_widths = [
+        max(len(h), max(len(r[i]) for r in rows))
+        for i, h in enumerate(headers)
+    ]
+
+    def _row(cells: tuple[str, ...]) -> str:
+        return "  ".join(cell.ljust(col_widths[i]) for i, cell in enumerate(cells)).rstrip()
+
+    sep = "  ".join("-" * w for w in col_widths)
+    lines = [_row(headers), sep] + [_row(r) for r in rows]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="List CAN interfaces and channels available on this machine."
+    )
+    parser.add_argument(
+        "--interface",
+        metavar="IFACE",
+        help="Probe only this python-can backend (e.g. socketcan, pcan, gs_usb).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="output_json",
+        help="Output as JSON array instead of a table.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level (default: WARNING)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(levelname)s: %(message)s",
+    )
+
+    interfaces = [args.interface] if args.interface else None
+    configs = gather_all(interfaces)
+
+    if args.output_json:
+        print(json.dumps(configs, indent=2))
+    else:
+        print(format_table(configs))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/hardware_bridge/server/test/test_list_can_interfaces.py
+++ b/tools/hardware_bridge/server/test/test_list_can_interfaces.py
@@ -1,0 +1,403 @@
+"""Tests for list_can_interfaces — all external dependencies are stubbed per test class."""
+
+import json
+import pathlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+SERVER_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+# ---------------------------------------------------------------------------
+# Minimal module-level stubs are required only to allow imports of modules
+# that transitively import can / candle_driver / serial at load time.
+# list_can_interfaces.py imports those lazily (inside functions), so these
+# stubs are just a safety net and are NOT relied on by the test assertions.
+# ---------------------------------------------------------------------------
+if "can" not in sys.modules:
+    _stub_can_bus = types.ModuleType("can.bus")
+    _stub_can = types.ModuleType("can")
+    _stub_can.BusABC = object
+    _stub_can.detect_available_configs = mock.Mock(return_value=[])
+    _stub_can.bus = _stub_can_bus
+    sys.modules["can"] = _stub_can
+    sys.modules["can.bus"] = _stub_can_bus
+
+if "candle_driver" not in sys.modules:
+    _stub_candle = types.ModuleType("candle_driver")
+    _stub_candle.CANDLE_ID_EXTENDED = 0x80000000
+    _stub_candle.list_devices = mock.Mock(return_value=[])
+    sys.modules["candle_driver"] = _stub_candle
+
+if "serial" not in sys.modules:
+    _stub_serial_lp = types.ModuleType("serial.tools.list_ports")
+    _stub_serial_lp.comports = mock.Mock(return_value=[])
+    _stub_serial_tools = types.ModuleType("serial.tools")
+    _stub_serial_tools.list_ports = _stub_serial_lp
+    _stub_serial = types.ModuleType("serial")
+    _stub_serial.Serial = mock.Mock()
+    _stub_serial.tools = _stub_serial_tools
+    sys.modules["serial"] = _stub_serial
+    sys.modules["serial.tools"] = _stub_serial_tools
+    sys.modules["serial.tools.list_ports"] = _stub_serial_lp
+
+import list_can_interfaces
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build isolated stubs for each test class
+# ---------------------------------------------------------------------------
+
+def _make_can_stub(return_value=None):
+    """Return a fresh (can, can.bus) stub pair with detect_available_configs mocked."""
+    stub_bus = types.ModuleType("can.bus")
+    stub_bus_state = mock.Mock(name="BusState")
+    stub_bus_state.ACTIVE = mock.sentinel.BUS_STATE_ACTIVE
+    stub_bus.BusState = stub_bus_state
+
+    stub_can = types.ModuleType("can")
+    stub_can.BusABC = object
+    stub_can.Bus = mock.Mock(name="Bus")
+    stub_can.detect_available_configs = mock.Mock(return_value=return_value or [])
+    stub_can.bus = stub_bus
+    return stub_can, stub_bus
+
+
+def _make_candle_stub(devices=None):
+    stub = types.ModuleType("candle_driver")
+    stub.CANDLE_ID_EXTENDED = 0x80000000
+    stub.list_devices = mock.Mock(return_value=devices or [])
+    return stub
+
+
+def _make_serial_stub(ports=None):
+    stub_lp = types.ModuleType("serial.tools.list_ports")
+    stub_lp.comports = mock.Mock(return_value=ports or [])
+    stub_tools = types.ModuleType("serial.tools")
+    stub_tools.list_ports = stub_lp
+    stub_serial = types.ModuleType("serial")
+    stub_serial.tools = stub_tools
+    return stub_serial, stub_tools, stub_lp
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestDetectPythonCanConfigs(unittest.TestCase):
+    def setUp(self):
+        self._can, self._can_bus = _make_can_stub()
+        self._patcher = mock.patch.dict(
+            sys.modules, {"can": self._can, "can.bus": self._can_bus}
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_returns_normalized_entries_for_found_configs(self):
+        self._can.detect_available_configs.return_value = [
+            {"interface": "socketcan", "channel": "can0"},
+            {"interface": "socketcan", "channel": "can1"},
+        ]
+
+        result = list_can_interfaces.detect_python_can_configs(interfaces=["socketcan"])
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["interface"], "socketcan")
+        self.assertEqual(result[0]["channel"], "can0")
+        self.assertEqual(result[0]["source"], "python-can")
+        self.assertEqual(result[1]["channel"], "can1")
+
+    def test_propagates_extra_backend_metadata(self):
+        self._can.detect_available_configs.return_value = [
+            {"interface": "pcan", "channel": "PCAN_USBBUS1", "supports_fd": True},
+        ]
+
+        result = list_can_interfaces.detect_python_can_configs(interfaces=["pcan"])
+
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0]["supports_fd"])
+
+    def test_returns_empty_list_when_no_configs_found(self):
+        self._can.detect_available_configs.return_value = []
+
+        result = list_can_interfaces.detect_python_can_configs(interfaces=["socketcan"])
+
+        self.assertEqual(result, [])
+
+    def test_skips_backend_on_exception_and_continues(self):
+        def side_effect(interfaces):
+            if "pcan" in interfaces:
+                raise RuntimeError("PCAN driver not found")
+            return [{"interface": "socketcan", "channel": "can0"}]
+
+        self._can.detect_available_configs.side_effect = side_effect
+
+        result = list_can_interfaces.detect_python_can_configs(
+            interfaces=["pcan", "socketcan"]
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["interface"], "socketcan")
+
+    def test_returns_empty_list_when_can_not_installed(self):
+        with mock.patch.dict(sys.modules, {"can": None}):
+            result = list_can_interfaces.detect_python_can_configs(interfaces=["socketcan"])
+
+        self.assertEqual(result, [])
+
+
+class TestDetectCandleDevices(unittest.TestCase):
+    def setUp(self):
+        self._candle = _make_candle_stub()
+        self._patcher = mock.patch.dict(sys.modules, {"candle_driver": self._candle})
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_returns_one_entry_per_device(self):
+        device_a = mock.Mock()
+        device_a.name = mock.Mock(return_value="CANable-v2 #0")
+        device_b = mock.Mock()
+        device_b.name = mock.Mock(return_value="CANable-v2 #1")
+        self._candle.list_devices.return_value = [device_a, device_b]
+
+        result = list_can_interfaces.detect_candle_devices()
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["interface"], "candle")
+        self.assertEqual(result[0]["channel"], "0")
+        self.assertEqual(result[0]["source"], "candle_driver")
+        self.assertEqual(result[1]["channel"], "1")
+
+    def test_returns_empty_list_when_no_devices(self):
+        self._candle.list_devices.return_value = []
+
+        result = list_can_interfaces.detect_candle_devices()
+
+        self.assertEqual(result, [])
+
+    def test_handles_list_devices_exception_gracefully(self):
+        self._candle.list_devices.side_effect = OSError("USB error")
+
+        result = list_can_interfaces.detect_candle_devices()
+
+        self.assertEqual(result, [])
+
+    def test_returns_empty_when_candle_driver_not_installed(self):
+        with mock.patch.dict(sys.modules, {"candle_driver": None}):
+            result = list_can_interfaces.detect_candle_devices()
+
+        self.assertEqual(result, [])
+
+
+class TestDetectSlcanSerialPorts(unittest.TestCase):
+    def setUp(self):
+        self._serial, self._serial_tools, self._list_ports = _make_serial_stub()
+        self._patcher = mock.patch.dict(
+            sys.modules,
+            {
+                "serial": self._serial,
+                "serial.tools": self._serial_tools,
+                "serial.tools.list_ports": self._list_ports,
+            },
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_returns_one_entry_per_serial_port(self):
+        port_a = mock.Mock()
+        port_a.device = "/dev/ttyACM0"
+        port_a.description = "CANable USB to CAN adapter"
+        port_b = mock.Mock()
+        port_b.device = "/dev/ttyACM1"
+        port_b.description = "USB Serial"
+        self._list_ports.comports.return_value = [port_a, port_b]
+
+        result = list_can_interfaces.detect_slcan_serial_ports()
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["interface"], "slcan")
+        self.assertEqual(result[0]["channel"], "/dev/ttyACM0")
+        self.assertEqual(result[0]["details"], "CANable USB to CAN adapter")
+        self.assertEqual(result[0]["source"], "serial-ports")
+        self.assertEqual(result[1]["channel"], "/dev/ttyACM1")
+
+    def test_returns_empty_list_when_no_ports(self):
+        self._list_ports.comports.return_value = []
+
+        result = list_can_interfaces.detect_slcan_serial_ports()
+
+        self.assertEqual(result, [])
+
+    def test_returns_empty_when_pyserial_not_installed(self):
+        with mock.patch.dict(sys.modules, {"serial.tools.list_ports": None}):
+            result = list_can_interfaces.detect_slcan_serial_ports()
+
+        self.assertEqual(result, [])
+
+
+class TestGatherAll(unittest.TestCase):
+    def test_aggregates_all_three_sources(self):
+        with (
+            mock.patch.object(
+                list_can_interfaces,
+                "detect_python_can_configs",
+                return_value=[{"interface": "socketcan", "channel": "can0", "source": "python-can"}],
+            ),
+            mock.patch.object(
+                list_can_interfaces,
+                "detect_candle_devices",
+                return_value=[{"interface": "candle", "channel": "0", "source": "candle_driver"}],
+            ),
+            mock.patch.object(
+                list_can_interfaces,
+                "detect_slcan_serial_ports",
+                return_value=[{"interface": "slcan", "channel": "/dev/ttyACM0", "source": "serial-ports"}],
+            ),
+        ):
+            result = list_can_interfaces.gather_all()
+
+        self.assertEqual(len(result), 3)
+        interfaces = {r["interface"] for r in result}
+        self.assertEqual(interfaces, {"socketcan", "candle", "slcan"})
+
+    def test_deduplicates_on_interface_and_channel(self):
+        duplicate_entry = {"interface": "socketcan", "channel": "can0", "source": "python-can"}
+        with (
+            mock.patch.object(
+                list_can_interfaces,
+                "detect_python_can_configs",
+                return_value=[duplicate_entry, duplicate_entry],
+            ),
+            mock.patch.object(list_can_interfaces, "detect_candle_devices", return_value=[]),
+            mock.patch.object(list_can_interfaces, "detect_slcan_serial_ports", return_value=[]),
+        ):
+            result = list_can_interfaces.gather_all()
+
+        self.assertEqual(len(result), 1)
+
+    def test_passes_interfaces_filter_to_python_can(self):
+        with (
+            mock.patch.object(
+                list_can_interfaces,
+                "detect_python_can_configs",
+                return_value=[],
+            ) as mock_detect,
+            mock.patch.object(list_can_interfaces, "detect_candle_devices", return_value=[]),
+            mock.patch.object(list_can_interfaces, "detect_slcan_serial_ports", return_value=[]),
+        ):
+            list_can_interfaces.gather_all(interfaces=["socketcan"])
+
+        mock_detect.assert_called_once_with(["socketcan"])
+
+
+class TestFormatTable(unittest.TestCase):
+    def test_returns_no_detected_message_for_empty_list(self):
+        result = list_can_interfaces.format_table([])
+
+        self.assertIn("No CAN interfaces detected", result)
+
+    def test_table_contains_header_and_separator(self):
+        configs = [{"interface": "socketcan", "channel": "can0", "source": "python-can"}]
+
+        result = list_can_interfaces.format_table(configs)
+
+        lines = result.splitlines()
+        self.assertIn("Interface", lines[0])
+        self.assertIn("Channel", lines[0])
+        self.assertIn("Source", lines[0])
+        self.assertRegex(lines[1], r"^-+")
+
+    def test_table_contains_config_data(self):
+        configs = [
+            {"interface": "socketcan", "channel": "can0", "source": "python-can"},
+            {"interface": "candle", "channel": "0", "details": "CANable", "source": "candle_driver"},
+        ]
+
+        result = list_can_interfaces.format_table(configs)
+
+        self.assertIn("socketcan", result)
+        self.assertIn("can0", result)
+        self.assertIn("candle", result)
+        self.assertIn("CANable", result)
+
+    def test_columns_are_aligned(self):
+        configs = [
+            {"interface": "socketcan", "channel": "can0", "source": "python-can"},
+            {"interface": "gs_usb", "channel": "0", "source": "python-can"},
+        ]
+
+        result = list_can_interfaces.format_table(configs)
+
+        lines = result.splitlines()
+        header_channel_pos = lines[0].index("Channel")
+        data_row_pos = lines[2].index(configs[0]["channel"])
+        self.assertEqual(header_channel_pos, data_row_pos)
+
+
+class TestBridgeServerListCan(unittest.IsolatedAsyncioTestCase):
+    """Verify --list-can causes bridge_server to print & exit without starting servers."""
+
+    async def test_list_can_prints_table_and_returns(self):
+        import bridge_server as bs
+
+        fake_configs = [{"interface": "socketcan", "channel": "can0", "source": "python-can"}]
+        fake_table = "Interface  Channel  Details  Source\n-----\nsocketcan  can0             python-can"
+
+        with (
+            mock.patch("list_can_interfaces.gather_all", return_value=fake_configs),
+            mock.patch("list_can_interfaces.format_table", return_value=fake_table),
+            mock.patch("sys.argv", ["bridge_server.py", "--list-can"]),
+            mock.patch("builtins.print") as mock_print,
+        ):
+            await bs.main()
+
+        mock_print.assert_called_once_with(fake_table)
+
+    async def test_list_can_json_outputs_json(self):
+        import bridge_server as bs
+
+        fake_configs = [{"interface": "socketcan", "channel": "can0", "source": "python-can"}]
+
+        with (
+            mock.patch("list_can_interfaces.gather_all", return_value=fake_configs),
+            mock.patch("sys.argv", ["bridge_server.py", "--list-can", "--json"]),
+            mock.patch("builtins.print") as mock_print,
+        ):
+            await bs.main()
+
+        printed = mock_print.call_args[0][0]
+        parsed = json.loads(printed)
+        self.assertEqual(parsed, fake_configs)
+
+    async def test_list_can_does_not_require_serial_or_can_interface(self):
+        """--list-can must bypass the 'specify at least one interface' guard."""
+        import bridge_server as bs
+
+        with (
+            mock.patch("list_can_interfaces.gather_all", return_value=[]),
+            mock.patch(
+                "list_can_interfaces.format_table",
+                return_value="No CAN interfaces detected.",
+            ),
+            mock.patch("sys.argv", ["bridge_server.py", "--list-can"]),
+            mock.patch("builtins.print"),
+            mock.patch.object(bs, "CanBusOverTcpServer") as mock_can_srv,
+            mock.patch.object(bs, "SerialOverTcpServer") as mock_serial_srv,
+        ):
+            await bs.main()
+
+        mock_can_srv.assert_not_called()
+        mock_serial_srv.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Replaces the generic `Leds()` array accessor in `PlatformFactory` with three named discrete GPIO methods: `OperationalLed()`, `WarningLed()`, and `FailureLed()`
- Adds `BoardId()` for 3-bit active-low CAN node identification via PK0–PK2 pull-up straps on TM4C1294XL
- Adds `PowerStatus()` for the LM5164 open-drain power-good signal on PC6
- Adds `E-FOC-HARDWARE` motor board definition with its analog front-end constants (21.25 V/V bus divider, 5 A/V current sensor, 12 A overcurrent trip) and compile-time `static_assert` verification
- `EK-TM4C123GXL` gains `hasBoardIdPins=false` / `hasPowerStatusPin=false` capability flags; placeholder pin declarations allow the shared `PlatformFactoryImpl` to compile for both boards without preprocessor guards

## Test plan

- [ ] Host build clean: `cmake --build --preset host-Debug`
- [ ] All 23 host tests pass: `ctest --preset host`
- [ ] TM4C1294XL embedded build clean: `cmake --build --preset EK-TM4C1294XL-Debug`
- [ ] STM32F407G-DISC1 embedded build clean: `cmake --build --preset STM32F407G-DISC1-Debug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)