### PR TITLE
feat: implement deferred stub commands in FocMotorCanBridge

### DIFF
--- a/core/can/FocMotorCanBridge.cpp
+++ b/core/can/FocMotorCanBridge.cpp
@@ -10,6 +10,7 @@ namespace can
         const drivers::ThreePhaseInverter& inverter,
         services::ElectricalParametersIdentification& electricalIdent,
         services::MechanicalParametersIdentification* mechIdent,
+        foc::NewtonMeter mechTorqueConstant,
         services::NonVolatileMemory& nvm,
         services::ConfigData configData,
         services::Tracer& tracer)
@@ -19,6 +20,7 @@ namespace can
         , inverter(inverter)
         , electricalIdent(electricalIdent)
         , mechIdent{ mechIdent }
+        , mechTorqueConstant{ mechTorqueConstant }
         , nvm(nvm)
         , configData(configData)
     {
@@ -243,7 +245,7 @@ namespace can
         pendingMechIdentDoneCallback = onDone;
 
         mechIdent->EstimateFrictionAndInertia(
-            foc::NewtonMeter{ cal.fluxLinkage },
+            mechTorqueConstant,
             static_cast<std::size_t>(cal.polePairs),
             {},
             [this](std::optional<foc::NewtonMeterSecondPerRadian> friction,

--- a/core/can/FocMotorCanBridge.cpp
+++ b/core/can/FocMotorCanBridge.cpp
@@ -8,11 +8,19 @@ namespace can
         FocMotorCategoryServer& server,
         state_machine::ControlModeStateMachine& controlMode,
         const drivers::ThreePhaseInverter& inverter,
+        services::ElectricalParametersIdentification& electricalIdent,
+        services::MechanicalParametersIdentification* mechIdent,
+        services::NonVolatileMemory& nvm,
+        services::ConfigData configData,
         services::Tracer& tracer)
         : FocMotorCategoryServerObserver(server)
         , server(server)
         , controlMode(controlMode)
         , inverter(inverter)
+        , electricalIdent(electricalIdent)
+        , mechIdent{ mechIdent }
+        , nvm(nvm)
+        , configData(configData)
     {
         tracer.Trace() << "FocMotorCanBridge: initialised";
     }
@@ -37,6 +45,17 @@ namespace can
             default:
                 return FocFaultCode::none;
         }
+    }
+
+    FocMotorState FocMotorCanBridge::ToCanMotorState(const state_machine::State& state)
+    {
+        if (std::holds_alternative<state_machine::Fault>(state))
+            return FocMotorState::fault;
+        if (std::holds_alternative<state_machine::Calibrating>(state))
+            return FocMotorState::calibrating;
+        if (std::holds_alternative<state_machine::Enabled>(state))
+            return FocMotorState::running;
+        return FocMotorState::idle;
     }
 
     void FocMotorCanBridge::OnStart(const infra::Function<void(services::CanAckStatus)>& onDone)
@@ -123,44 +142,192 @@ namespace can
             server.SendCategoryError(can::focSetPositionSetpointId, FocMotorCategoryError::modeMismatch);
     }
 
-    void FocMotorCanBridge::OnSetPidCurrent(const infra::Function<void()>&)
+    void FocMotorCanBridge::OnSetPidCurrent(float bandwidth, const infra::Function<void()>& onDone)
     {
-        server.SendCategoryError(can::focSetPidCurrentId, FocMotorCategoryError::applicationError);
+        if (!controlMode.TrySetCurrentBandwidth(bandwidth))
+        {
+            server.SendCommandAck(can::focSetPidCurrentId, services::CanAckStatus::invalidPayload);
+            return;
+        }
+        onDone();
     }
 
-    void FocMotorCanBridge::OnSetPidSpeed(const infra::Function<void()>&)
+    void FocMotorCanBridge::OnSetPidSpeed(float bandwidth, const infra::Function<void()>& onDone)
     {
-        server.SendCategoryError(can::focSetPidSpeedId, FocMotorCategoryError::applicationError);
+        if (!controlMode.TrySetSpeedBandwidth(bandwidth))
+        {
+            server.SendCommandAck(can::focSetPidSpeedId, services::CanAckStatus::invalidPayload);
+            return;
+        }
+        onDone();
     }
 
-    void FocMotorCanBridge::OnSetPidPosition(const infra::Function<void()>&)
+    void FocMotorCanBridge::OnSetPidPosition(float bandwidth, const infra::Function<void()>& onDone)
     {
-        server.SendCategoryError(can::focSetPidPositionId, FocMotorCategoryError::applicationError);
+        if (!controlMode.TrySetPositionBandwidth(bandwidth))
+        {
+            server.SendCommandAck(can::focSetPidPositionId, services::CanAckStatus::invalidPayload);
+            return;
+        }
+        onDone();
     }
 
-    void FocMotorCanBridge::OnIdentifyElectrical(const infra::Function<void()>&)
+    void FocMotorCanBridge::OnIdentifyElectrical(const infra::Function<void()>& onDone)
     {
-        server.SendCategoryError(can::focIdentifyElectricalId, FocMotorCategoryError::applicationError);
+        if (pendingElectricalIdentDoneCallback != nullptr)
+        {
+            server.SendCategoryError(can::focIdentifyElectricalId, FocMotorCategoryError::busy);
+            return;
+        }
+
+        pendingElectricalIdentDoneCallback = onDone;
+
+        electricalIdent.EstimateResistanceAndInductance({},
+            [this](std::optional<foc::Ohm> r, std::optional<foc::MilliHenry> l)
+            {
+                if (!r.has_value() || !l.has_value())
+                {
+                    pendingElectricalIdentDoneCallback = nullptr;
+                    server.SendCategoryError(can::focIdentifyElectricalId, FocMotorCategoryError::calibrationFailed);
+                    return;
+                }
+
+                pendingElectricalR = r;
+                pendingElectricalL = l;
+
+                electricalIdent.EstimateNumberOfPolePairs({},
+                    [this](std::optional<std::size_t> polePairs)
+                    {
+                        auto callback = pendingElectricalIdentDoneCallback;
+                        pendingElectricalIdentDoneCallback = nullptr;
+
+                        if (!polePairs.has_value())
+                        {
+                            pendingElectricalR.reset();
+                            pendingElectricalL.reset();
+                            server.SendCategoryError(can::focIdentifyElectricalId, FocMotorCategoryError::calibrationFailed);
+                            return;
+                        }
+
+                        server.BroadcastElectricalParams(*pendingElectricalR, *pendingElectricalL, *polePairs);
+                        pendingElectricalR.reset();
+                        pendingElectricalL.reset();
+                        callback();
+                    });
+            });
     }
 
-    void FocMotorCanBridge::OnIdentifyMechanical(const infra::Function<void()>&)
+    void FocMotorCanBridge::OnIdentifyMechanical(const infra::Function<void()>& onDone)
     {
-        server.SendCategoryError(can::focIdentifyMechanicalId, FocMotorCategoryError::applicationError);
+        if (mechIdent == nullptr)
+        {
+            server.SendCommandAck(can::focIdentifyMechanicalId, services::CanAckStatus::notImplemented);
+            return;
+        }
+
+        if (pendingMechIdentDoneCallback != nullptr)
+        {
+            server.SendCategoryError(can::focIdentifyMechanicalId, FocMotorCategoryError::busy);
+            return;
+        }
+
+        const auto& state = controlMode.ActiveStateMachine().CurrentState();
+        const auto* ready = std::get_if<state_machine::Ready>(&state);
+        if (ready == nullptr)
+        {
+            server.SendCommandAck(can::focIdentifyMechanicalId, services::CanAckStatus::invalidState);
+            return;
+        }
+
+        const auto& cal = ready->loadedData;
+        pendingMechIdentDoneCallback = onDone;
+
+        mechIdent->EstimateFrictionAndInertia(
+            foc::NewtonMeter{ cal.fluxLinkage },
+            static_cast<std::size_t>(cal.polePairs),
+            {},
+            [this](std::optional<foc::NewtonMeterSecondPerRadian> friction,
+                   std::optional<foc::NewtonMeterSecondSquared> inertia)
+            {
+                auto callback = pendingMechIdentDoneCallback;
+                pendingMechIdentDoneCallback = nullptr;
+
+                if (!friction.has_value() || !inertia.has_value())
+                {
+                    server.SendCategoryError(can::focIdentifyMechanicalId, FocMotorCategoryError::calibrationFailed);
+                    return;
+                }
+
+                server.BroadcastMechanicalParams(*friction, *inertia);
+                callback();
+            });
     }
 
-    void FocMotorCanBridge::OnRequestTelemetry(const infra::Function<void()>&)
+    void FocMotorCanBridge::OnRequestTelemetry(const infra::Function<void()>& onDone)
     {
-        server.SendCategoryError(can::focRequestTelemetryId, FocMotorCategoryError::applicationError);
+        const auto& state = controlMode.ActiveStateMachine().CurrentState();
+        const auto faultCode = std::holds_alternative<state_machine::Fault>(state)
+            ? ToCanFaultCode(controlMode.ActiveStateMachine().LastFaultCode())
+            : FocFaultCode::none;
+
+        server.BroadcastTelemetryStatus(ToCanMotorState(state), faultCode);
+        onDone();
     }
 
-    void FocMotorCanBridge::OnSetEncoderResolution(const infra::Function<void()>&)
+    void FocMotorCanBridge::OnSetEncoderResolution(uint32_t resolution, const infra::Function<void()>& onDone)
     {
-        server.SendCategoryError(can::focSetEncoderResolutionId, FocMotorCategoryError::applicationError);
+        if (pendingNvmDoneCallback != nullptr)
+        {
+            server.SendCategoryError(can::focSetEncoderResolutionId, FocMotorCategoryError::busy);
+            return;
+        }
+
+        if (resolution == 0)
+        {
+            server.SendCommandAck(can::focSetEncoderResolutionId, services::CanAckStatus::invalidPayload);
+            return;
+        }
+
+        configData.encoderResolution = resolution;
+        pendingNvmDoneCallback = onDone;
+
+        nvm.SaveConfig(configData, [this](services::NvmStatus status)
+            {
+                auto callback = pendingNvmDoneCallback;
+                pendingNvmDoneCallback = nullptr;
+                if (status == services::NvmStatus::Ok)
+                    callback();
+                else
+                    server.SendCategoryError(can::focSetEncoderResolutionId, FocMotorCategoryError::persistenceFailed);
+            });
     }
 
-    void FocMotorCanBridge::OnConfigureTelemetryRate(const infra::Function<void()>&)
+    void FocMotorCanBridge::OnConfigureTelemetryRate(uint32_t rateHz, const infra::Function<void()>& onDone)
     {
-        server.SendCategoryError(can::focConfigureTelemetryRateId, FocMotorCategoryError::applicationError);
+        if (pendingNvmDoneCallback != nullptr)
+        {
+            server.SendCategoryError(can::focConfigureTelemetryRateId, FocMotorCategoryError::busy);
+            return;
+        }
+
+        if (rateHz == 0 || rateHz > 10000)
+        {
+            server.SendCommandAck(can::focConfigureTelemetryRateId, services::CanAckStatus::invalidPayload);
+            return;
+        }
+
+        configData.telemetryRateHz = rateHz;
+        pendingNvmDoneCallback = onDone;
+
+        nvm.SaveConfig(configData, [this](services::NvmStatus status)
+            {
+                auto callback = pendingNvmDoneCallback;
+                pendingNvmDoneCallback = nullptr;
+                if (status == services::NvmStatus::Ok)
+                    callback();
+                else
+                    server.SendCategoryError(can::focConfigureTelemetryRateId, FocMotorCategoryError::persistenceFailed);
+            });
     }
 
     void FocMotorCanBridge::ReportCommandOutcome(uint8_t commandId, state_machine::CommandResult result,

--- a/core/can/FocMotorCanBridge.cpp
+++ b/core/can/FocMotorCanBridge.cpp
@@ -247,7 +247,7 @@ namespace can
             static_cast<std::size_t>(cal.polePairs),
             {},
             [this](std::optional<foc::NewtonMeterSecondPerRadian> friction,
-                   std::optional<foc::NewtonMeterSecondSquared> inertia)
+                std::optional<foc::NewtonMeterSecondSquared> inertia)
             {
                 auto callback = pendingMechIdentDoneCallback;
                 pendingMechIdentDoneCallback = nullptr;
@@ -267,8 +267,8 @@ namespace can
     {
         const auto& state = controlMode.ActiveStateMachine().CurrentState();
         const auto faultCode = std::holds_alternative<state_machine::Fault>(state)
-            ? ToCanFaultCode(controlMode.ActiveStateMachine().LastFaultCode())
-            : FocFaultCode::none;
+                                   ? ToCanFaultCode(controlMode.ActiveStateMachine().LastFaultCode())
+                                   : FocFaultCode::none;
 
         server.BroadcastTelemetryStatus(ToCanMotorState(state), faultCode);
         onDone();

--- a/core/can/FocMotorCanBridge.hpp
+++ b/core/can/FocMotorCanBridge.hpp
@@ -2,11 +2,16 @@
 
 #include "core/can/FocMotorCategoryServer.hpp"
 #include "core/platform_abstraction/interfaces/Drivers.hpp"
+#include "core/services/electrical_system_ident/ElectricalParametersIdentification.hpp"
+#include "core/services/mechanical_system_ident/MechanicalParametersIdentification.hpp"
+#include "core/services/non_volatile_memory/ConfigData.hpp"
+#include "core/services/non_volatile_memory/NonVolatileMemory.hpp"
 #include "core/state_machine/ControlMode.hpp"
 #include "core/state_machine/ControlModeStateMachine.hpp"
 #include "core/state_machine/FaultNotifier.hpp"
 #include "infra/util/Function.hpp"
 #include "services/tracer/Tracer.hpp"
+#include <optional>
 
 namespace can
 {
@@ -18,6 +23,10 @@ namespace can
             FocMotorCategoryServer& server,
             state_machine::ControlModeStateMachine& controlMode,
             const drivers::ThreePhaseInverter& inverter,
+            services::ElectricalParametersIdentification& electricalIdent,
+            services::MechanicalParametersIdentification* mechIdent,
+            services::NonVolatileMemory& nvm,
+            services::ConfigData configData,
             services::Tracer& tracer);
 
         static constexpr float maxPositionSetpoint{ 6.2831853f };
@@ -34,17 +43,18 @@ namespace can
         void OnSetSpeedSetpoint(foc::RadiansPerSecond value, const infra::Function<void()>& onDone) override;
         void OnSetPositionSetpoint(foc::Radians value, const infra::Function<void()>& onDone) override;
 
-        void OnSetPidCurrent(const infra::Function<void()>& onDone) override;
-        void OnSetPidSpeed(const infra::Function<void()>& onDone) override;
-        void OnSetPidPosition(const infra::Function<void()>& onDone) override;
+        void OnSetPidCurrent(float bandwidth, const infra::Function<void()>& onDone) override;
+        void OnSetPidSpeed(float bandwidth, const infra::Function<void()>& onDone) override;
+        void OnSetPidPosition(float bandwidth, const infra::Function<void()>& onDone) override;
         void OnIdentifyElectrical(const infra::Function<void()>& onDone) override;
         void OnIdentifyMechanical(const infra::Function<void()>& onDone) override;
         void OnRequestTelemetry(const infra::Function<void()>& onDone) override;
-        void OnSetEncoderResolution(const infra::Function<void()>& onDone) override;
-        void OnConfigureTelemetryRate(const infra::Function<void()>& onDone) override;
+        void OnSetEncoderResolution(uint32_t resolution, const infra::Function<void()>& onDone) override;
+        void OnConfigureTelemetryRate(uint32_t rateHz, const infra::Function<void()>& onDone) override;
 
     private:
         static FocFaultCode ToCanFaultCode(state_machine::FaultCode code);
+        static FocMotorState ToCanMotorState(const state_machine::State& state);
 
         void ReportCommandOutcome(uint8_t commandId, state_machine::CommandResult result,
             const infra::Function<void(services::CanAckStatus)>& onDone);
@@ -55,6 +65,16 @@ namespace can
         FocMotorCategoryServer& server;
         state_machine::ControlModeStateMachine& controlMode;
         const drivers::ThreePhaseInverter& inverter;
+        services::ElectricalParametersIdentification& electricalIdent;
+        services::MechanicalParametersIdentification* mechIdent;
+        services::NonVolatileMemory& nvm;
+        services::ConfigData configData;
+
         infra::Function<void(FocMotorMode)> pendingSelectCallback;
+        infra::Function<void()> pendingElectricalIdentDoneCallback;
+        infra::Function<void()> pendingMechIdentDoneCallback;
+        infra::Function<void()> pendingNvmDoneCallback;
+        std::optional<foc::Ohm> pendingElectricalR;
+        std::optional<foc::MilliHenry> pendingElectricalL;
     };
 }

--- a/core/can/FocMotorCanBridge.hpp
+++ b/core/can/FocMotorCanBridge.hpp
@@ -25,6 +25,7 @@ namespace can
             const drivers::ThreePhaseInverter& inverter,
             services::ElectricalParametersIdentification& electricalIdent,
             services::MechanicalParametersIdentification* mechIdent,
+            foc::NewtonMeter mechTorqueConstant,
             services::NonVolatileMemory& nvm,
             services::ConfigData configData,
             services::Tracer& tracer);
@@ -67,6 +68,7 @@ namespace can
         const drivers::ThreePhaseInverter& inverter;
         services::ElectricalParametersIdentification& electricalIdent;
         services::MechanicalParametersIdentification* mechIdent;
+        foc::NewtonMeter mechTorqueConstant;
         services::NonVolatileMemory& nvm;
         services::ConfigData configData;
 

--- a/core/can/FocMotorCategoryServer.cpp
+++ b/core/can/FocMotorCategoryServer.cpp
@@ -168,33 +168,57 @@ namespace can
             });
     }
 
-    void FocMotorCategoryServer::HandleSetPidCurrent(const hal::Can::Message&)
+    void FocMotorCategoryServer::HandleSetPidCurrent(const hal::Can::Message& data)
     {
-        NotifyObservers([this](auto& observer)
+        services::CanPayloadReader reader{ data };
+        reader.Skip(1);
+        const auto bandwidth = reader.ReadFixed16(focPidScale);
+        if (!reader.Valid())
+        {
+            SendCommandAck(focSetPidCurrentId, services::CanAckStatus::invalidPayload);
+            return;
+        }
+        NotifyObservers([this, bandwidth](auto& observer)
             {
-                observer.OnSetPidCurrent([this]()
+                observer.OnSetPidCurrent(bandwidth, [this]()
                     {
                         SendCommandAck(focSetPidCurrentId, services::CanAckStatus::success);
                     });
             });
     }
 
-    void FocMotorCategoryServer::HandleSetPidSpeed(const hal::Can::Message&)
+    void FocMotorCategoryServer::HandleSetPidSpeed(const hal::Can::Message& data)
     {
-        NotifyObservers([this](auto& observer)
+        services::CanPayloadReader reader{ data };
+        reader.Skip(1);
+        const auto bandwidth = reader.ReadFixed16(focPidScale);
+        if (!reader.Valid())
+        {
+            SendCommandAck(focSetPidSpeedId, services::CanAckStatus::invalidPayload);
+            return;
+        }
+        NotifyObservers([this, bandwidth](auto& observer)
             {
-                observer.OnSetPidSpeed([this]()
+                observer.OnSetPidSpeed(bandwidth, [this]()
                     {
                         SendCommandAck(focSetPidSpeedId, services::CanAckStatus::success);
                     });
             });
     }
 
-    void FocMotorCategoryServer::HandleSetPidPosition(const hal::Can::Message&)
+    void FocMotorCategoryServer::HandleSetPidPosition(const hal::Can::Message& data)
     {
-        NotifyObservers([this](auto& observer)
+        services::CanPayloadReader reader{ data };
+        reader.Skip(1);
+        const auto bandwidth = reader.ReadFixed16(focPidScale);
+        if (!reader.Valid())
+        {
+            SendCommandAck(focSetPidPositionId, services::CanAckStatus::invalidPayload);
+            return;
+        }
+        NotifyObservers([this, bandwidth](auto& observer)
             {
-                observer.OnSetPidPosition([this]()
+                observer.OnSetPidPosition(bandwidth, [this]()
                     {
                         SendCommandAck(focSetPidPositionId, services::CanAckStatus::success);
                     });
@@ -234,11 +258,19 @@ namespace can
             });
     }
 
-    void FocMotorCategoryServer::HandleSetEncoderResolution(const hal::Can::Message&)
+    void FocMotorCategoryServer::HandleSetEncoderResolution(const hal::Can::Message& data)
     {
-        NotifyObservers([this](auto& observer)
+        services::CanPayloadReader reader{ data };
+        reader.Skip(1);
+        const auto resolution = reader.ReadUInt32();
+        if (!reader.Valid())
+        {
+            SendCommandAck(focSetEncoderResolutionId, services::CanAckStatus::invalidPayload);
+            return;
+        }
+        NotifyObservers([this, resolution](auto& observer)
             {
-                observer.OnSetEncoderResolution([this]()
+                observer.OnSetEncoderResolution(resolution, [this]()
                     {
                         SendCommandAck(focSetEncoderResolutionId, services::CanAckStatus::success);
                     });
@@ -250,14 +282,49 @@ namespace can
         SendCommandAck(focQueryMotorTypeId, services::CanAckStatus::notImplemented);
     }
 
-    void FocMotorCategoryServer::HandleConfigureTelemetryRate(const hal::Can::Message&)
+    void FocMotorCategoryServer::HandleConfigureTelemetryRate(const hal::Can::Message& data)
     {
-        NotifyObservers([this](auto& observer)
+        services::CanPayloadReader reader{ data };
+        reader.Skip(1);
+        const auto rateHz = reader.ReadUInt32();
+        if (!reader.Valid())
+        {
+            SendCommandAck(focConfigureTelemetryRateId, services::CanAckStatus::invalidPayload);
+            return;
+        }
+        NotifyObservers([this, rateHz](auto& observer)
             {
-                observer.OnConfigureTelemetryRate([this]()
+                observer.OnConfigureTelemetryRate(rateHz, [this]()
                     {
                         SendCommandAck(focConfigureTelemetryRateId, services::CanAckStatus::success);
                     });
             });
+    }
+
+    void FocMotorCategoryServer::BroadcastTelemetryStatus(FocMotorState state, FocFaultCode fault)
+    {
+        services::CanPayloadWriter payload;
+        payload.WriteUInt8(static_cast<uint8_t>(state));
+        payload.WriteUInt8(static_cast<uint8_t>(fault));
+        payload.WriteFixed16(0.0f, focSpeedScale);
+        payload.WriteFixed16(0.0f, focPositionScale);
+        SendTelemetry(focTelemetryStatusResponseId, payload);
+    }
+
+    void FocMotorCategoryServer::BroadcastElectricalParams(foc::Ohm resistance, foc::MilliHenry inductance, std::size_t polePairs)
+    {
+        services::CanPayloadWriter payload;
+        payload.WriteFixed16(resistance.Value(), focResistanceScale);
+        payload.WriteFixed16(inductance.Value(), focInductanceScale);
+        payload.WriteUInt8(static_cast<uint8_t>(polePairs));
+        SendResponse(focElectricalParamsResponseId, payload);
+    }
+
+    void FocMotorCategoryServer::BroadcastMechanicalParams(foc::NewtonMeterSecondPerRadian friction, foc::NewtonMeterSecondSquared inertia)
+    {
+        services::CanPayloadWriter payload;
+        payload.WriteFixed16(friction.Value(), focFrictionScale);
+        payload.WriteFixed16(inertia.Value(), focInertiaScale);
+        SendResponse(focMechanicalParamsResponseId, payload);
     }
 }

--- a/core/can/FocMotorCategoryServer.cpp
+++ b/core/can/FocMotorCategoryServer.cpp
@@ -33,12 +33,7 @@ namespace can
 
     void FocMotorCategoryServer::BroadcastFaultStatus(FocFaultCode fault)
     {
-        services::CanPayloadWriter payload;
-        payload.WriteUInt8(static_cast<uint8_t>(FocMotorState::fault));
-        payload.WriteUInt8(static_cast<uint8_t>(fault));
-        payload.WriteFixed16(0.0f, focSpeedScale);
-        payload.WriteFixed16(0.0f, focPositionScale);
-        SendTelemetry(focTelemetryStatusResponseId, payload);
+        BroadcastTelemetryStatus(FocMotorState::fault, fault);
     }
 
     void FocMotorCategoryServer::HandleStart(const hal::Can::Message&)

--- a/core/can/FocMotorCategoryServer.hpp
+++ b/core/can/FocMotorCategoryServer.hpp
@@ -29,14 +29,14 @@ namespace can
         virtual void OnSetSpeedSetpoint(foc::RadiansPerSecond value, const infra::Function<void()>& onDone) = 0;
         virtual void OnSetPositionSetpoint(foc::Radians value, const infra::Function<void()>& onDone) = 0;
 
-        virtual void OnSetPidCurrent(const infra::Function<void()>& onDone) = 0;
-        virtual void OnSetPidSpeed(const infra::Function<void()>& onDone) = 0;
-        virtual void OnSetPidPosition(const infra::Function<void()>& onDone) = 0;
+        virtual void OnSetPidCurrent(float bandwidth, const infra::Function<void()>& onDone) = 0;
+        virtual void OnSetPidSpeed(float bandwidth, const infra::Function<void()>& onDone) = 0;
+        virtual void OnSetPidPosition(float bandwidth, const infra::Function<void()>& onDone) = 0;
         virtual void OnIdentifyElectrical(const infra::Function<void()>& onDone) = 0;
         virtual void OnIdentifyMechanical(const infra::Function<void()>& onDone) = 0;
         virtual void OnRequestTelemetry(const infra::Function<void()>& onDone) = 0;
-        virtual void OnSetEncoderResolution(const infra::Function<void()>& onDone) = 0;
-        virtual void OnConfigureTelemetryRate(const infra::Function<void()>& onDone) = 0;
+        virtual void OnSetEncoderResolution(uint32_t resolution, const infra::Function<void()>& onDone) = 0;
+        virtual void OnConfigureTelemetryRate(uint32_t rateHz, const infra::Function<void()>& onDone) = 0;
     };
 
     class FocMotorCategoryServer
@@ -53,6 +53,9 @@ namespace can
         void SendSelectControlModeResponse(FocMotorMode activeMode);
         void SendCategoryError(uint8_t origCommandId, FocMotorCategoryError errorCode);
         void BroadcastFaultStatus(FocFaultCode fault);
+        void BroadcastTelemetryStatus(FocMotorState state, FocFaultCode fault);
+        void BroadcastElectricalParams(foc::Ohm resistance, foc::MilliHenry inductance, std::size_t polePairs);
+        void BroadcastMechanicalParams(foc::NewtonMeterSecondPerRadian friction, foc::NewtonMeterSecondSquared inertia);
 
     private:
         void HandleStart(const hal::Can::Message& data);

--- a/core/can/FocMotorMessages.hpp
+++ b/core/can/FocMotorMessages.hpp
@@ -74,6 +74,8 @@ namespace can
     static constexpr int32_t focResistanceScale = 1000;
     static constexpr int32_t focInductanceScale = 1000;
     static constexpr int32_t focPidScale = 1;
+    static constexpr int32_t focFrictionScale = 10000;
+    static constexpr int32_t focInertiaScale = 10000;
 
     static constexpr uint8_t focPidAxisId = 0x00;
     static constexpr uint8_t focPidAxisIq = 0x01;

--- a/core/can/test/TestFocMotorCanBridge.cpp
+++ b/core/can/test/TestFocMotorCanBridge.cpp
@@ -169,7 +169,7 @@ namespace
                     hal::Hertz{ 1000 },
                     lowPriorityInterruptMock });
 
-            bridge.emplace(*motorServer, *coordinator, inverterMock, electricalIdentMock, &mechIdentMock, nvmMock, config, tracer);
+            bridge.emplace(*motorServer, *coordinator, inverterMock, electricalIdentMock, &mechIdentMock, foc::NewtonMeter{ 0.1f }, nvmMock, config, tracer);
             motorServer->SetAcknowledger(ackSpy);
             ExecuteAllActions();
         }
@@ -741,6 +741,198 @@ namespace
         EXPECT_EQ(services::CanFrameCodec::ReadInt16(lastSentData, 4), 0);
     }
 
+    TEST_F(FocMotorCanBridgeTest, OnSetPidSpeed_InTorqueMode_RejectsInvalidPayload)
+    {
+        ConstructFixture();
+        ResetCaptures();
+
+        DispatchSetpoint(can::focSetPidSpeedId, 100);
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::invalidPayload);
+        EXPECT_FALSE(categoryErrorSent);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnSetPidPosition_InTorqueMode_RejectsInvalidPayload)
+    {
+        ConstructFixture();
+        ResetCaptures();
+
+        DispatchSetpoint(can::focSetPidPositionId, 18);
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::invalidPayload);
+        EXPECT_FALSE(categoryErrorSent);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnIdentifyMechanical_NullMechIdent_ReturnsNotImplemented)
+    {
+        GivenNvmAlwaysInvalid();
+        services::ConfigData config{};
+        coordinator.emplace(
+            application::TerminalAndTracer{ terminal, tracer },
+            application::MotorHardware{ inverterMock, encoderMock, foc::Volts{ 24.0f } },
+            nvmMock,
+            application::CalibrationServices{ electricalIdentMock, alignmentMock, std::ref(mechIdentMock) },
+            faultNotifierMock,
+            config,
+            state_machine::ControlModeStateMachine::OuterLoopArgs{
+                foc::Ampere{ 10.0f },
+                hal::Hertz{ 1000 },
+                lowPriorityInterruptMock });
+        bridge.emplace(*motorServer, *coordinator, inverterMock, electricalIdentMock, nullptr, foc::NewtonMeter{ 0.1f }, nvmMock, config, tracer);
+        motorServer->SetAcknowledger(ackSpy);
+        ExecuteAllActions();
+        ResetCaptures();
+
+        Dispatch(can::focIdentifyMechanicalId, {});
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::notImplemented);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnIdentifyElectrical_SecondStepFails_SendsCalibrationFailed)
+    {
+        ConstructFixture();
+
+        EXPECT_CALL(electricalIdentMock, EstimateResistanceAndInductance(_, _))
+            .WillOnce(Invoke([](const services::ElectricalParametersIdentification::ResistanceAndInductanceConfig&,
+                               infra::Function<void(std::optional<foc::Ohm>, std::optional<foc::MilliHenry>)> done)
+                {
+                    done(foc::Ohm{ 0.5f }, foc::MilliHenry{ 1.0f });
+                }));
+        EXPECT_CALL(electricalIdentMock, EstimateNumberOfPolePairs(_, _))
+            .WillOnce(Invoke([](const services::ElectricalParametersIdentification::PolePairsConfig&,
+                               infra::Function<void(std::optional<std::size_t>)> done)
+                {
+                    done(std::nullopt);
+                }));
+
+        ResetCaptures();
+        Dispatch(can::focIdentifyElectricalId, {});
+
+        EXPECT_TRUE(categoryErrorSent);
+        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::calibrationFailed);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnIdentifyElectrical_WhilePending_ReturnsBusy)
+    {
+        ConstructFixture();
+
+        infra::Function<void(std::optional<foc::Ohm>, std::optional<foc::MilliHenry>)> capturedCallback;
+        EXPECT_CALL(electricalIdentMock, EstimateResistanceAndInductance(_, _))
+            .WillOnce(Invoke([&capturedCallback](const services::ElectricalParametersIdentification::ResistanceAndInductanceConfig&,
+                               infra::Function<void(std::optional<foc::Ohm>, std::optional<foc::MilliHenry>)> done)
+                {
+                    capturedCallback = done;
+                }));
+
+        motorServer->HandleMessage(can::focIdentifyElectricalId, {});
+
+        ResetCaptures();
+        Dispatch(can::focIdentifyElectricalId, {});
+
+        EXPECT_TRUE(categoryErrorSent);
+        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::busy);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnIdentifyMechanical_WhilePending_ReturnsBusy)
+    {
+        ConstructFixtureInReady();
+
+        infra::Function<void(std::optional<foc::NewtonMeterSecondPerRadian>, std::optional<foc::NewtonMeterSecondSquared>)> capturedCallback;
+        EXPECT_CALL(mechIdentMock, EstimateFrictionAndInertia(_, _, _, _))
+            .WillOnce(Invoke([&capturedCallback](const foc::NewtonMeter&, std::size_t,
+                               const services::MechanicalParametersIdentification::Config&,
+                               infra::Function<void(std::optional<foc::NewtonMeterSecondPerRadian>,
+                                   std::optional<foc::NewtonMeterSecondSquared>)> done)
+                {
+                    capturedCallback = done;
+                }));
+
+        motorServer->HandleMessage(can::focIdentifyMechanicalId, {});
+
+        ResetCaptures();
+        Dispatch(can::focIdentifyMechanicalId, {});
+
+        EXPECT_TRUE(categoryErrorSent);
+        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::busy);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnSetEncoderResolution_NvmFails_SendsPersistenceFailed)
+    {
+        ConstructFixture();
+
+        EXPECT_CALL(nvmMock, SaveConfig(_, _))
+            .WillOnce(Invoke([](const services::ConfigData&, infra::Function<void(services::NvmStatus)> done)
+                {
+                    done(services::NvmStatus::WriteFailed);
+                }));
+
+        ResetCaptures();
+        DispatchUInt32Command(can::focSetEncoderResolutionId, 4000);
+
+        EXPECT_TRUE(categoryErrorSent);
+        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::persistenceFailed);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnSetEncoderResolution_WhileNvmPending_ReturnsBusy)
+    {
+        ConstructFixture();
+
+        infra::Function<void(services::NvmStatus)> capturedNvmCallback;
+        EXPECT_CALL(nvmMock, SaveConfig(_, _))
+            .WillOnce(Invoke([&capturedNvmCallback](const services::ConfigData&, infra::Function<void(services::NvmStatus)> done)
+                {
+                    capturedNvmCallback = done;
+                }));
+
+        motorServer->HandleMessage(can::focSetEncoderResolutionId, []{
+            hal::Can::Message d; d.resize(5, 0);
+            services::CanFrameCodec::WriteUInt32(d, 1, 4000);
+            return d;
+        }());
+
+        ResetCaptures();
+        DispatchUInt32Command(can::focSetEncoderResolutionId, 8000);
+
+        EXPECT_TRUE(categoryErrorSent);
+        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::busy);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnConfigureTelemetryRate_NvmFails_SendsPersistenceFailed)
+    {
+        ConstructFixture();
+
+        EXPECT_CALL(nvmMock, SaveConfig(_, _))
+            .WillOnce(Invoke([](const services::ConfigData&, infra::Function<void(services::NvmStatus)> done)
+                {
+                    done(services::NvmStatus::WriteFailed);
+                }));
+
+        ResetCaptures();
+        DispatchUInt32Command(can::focConfigureTelemetryRateId, 100);
+
+        EXPECT_TRUE(categoryErrorSent);
+        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::persistenceFailed);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnRequestTelemetry_InFaultState_BroadcastsFaultStatus)
+    {
+        ConstructFixtureInReady();
+        Dispatch(can::focStartId, {});
+        faultNotifierMock.TriggerFault(state_machine::FaultCode::overcurrent);
+        ExecuteAllActions();
+        ResetCaptures();
+
+        Dispatch(can::focRequestTelemetryId, {});
+
+        EXPECT_EQ(lastSentMsgType, can::focTelemetryStatusResponseId);
+        ASSERT_GE(lastSentData.size(), 2u);
+        EXPECT_EQ(lastSentData[0], static_cast<uint8_t>(can::FocMotorState::fault));
+        EXPECT_EQ(lastSentData[1], static_cast<uint8_t>(can::FocFaultCode::overCurrent));
+    }
+
     // REQ-INT-012 — ctor emits one trace line
     TEST_F(FocMotorCanBridgeTest, Constructor_EmitsTraceMessage)
     {
@@ -761,7 +953,7 @@ namespace
                 hal::Hertz{ 1000 },
                 lowPriorityInterruptMock });
 
-        bridge.emplace(*motorServer, *coordinator, inverterMock, electricalIdentMock, &mechIdentMock, nvmMock, config, tracer);
+        bridge.emplace(*motorServer, *coordinator, inverterMock, electricalIdentMock, &mechIdentMock, foc::NewtonMeter{ 0.1f }, nvmMock, config, tracer);
         motorServer->SetAcknowledger(ackSpy);
         ExecuteAllActions();
     }

--- a/core/can/test/TestFocMotorCanBridge.cpp
+++ b/core/can/test/TestFocMotorCanBridge.cpp
@@ -169,7 +169,7 @@ namespace
                     hal::Hertz{ 1000 },
                     lowPriorityInterruptMock });
 
-            bridge.emplace(*motorServer, *coordinator, inverterMock, tracer);
+            bridge.emplace(*motorServer, *coordinator, inverterMock, electricalIdentMock, &mechIdentMock, nvmMock, config, tracer);
             motorServer->SetAcknowledger(ackSpy);
             ExecuteAllActions();
         }
@@ -209,6 +209,14 @@ namespace
             hal::Can::Message data;
             data.resize(3, 0);
             services::CanFrameCodec::WriteInt16(data, 1, wireValue);
+            Dispatch(commandId, data);
+        }
+
+        void DispatchUInt32Command(uint8_t commandId, uint32_t value)
+        {
+            hal::Can::Message data;
+            data.resize(5, 0);
+            services::CanFrameCodec::WriteUInt32(data, 1, value);
             Dispatch(commandId, data);
         }
 
@@ -298,45 +306,42 @@ namespace
         EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
     }
 
-    // REQ-INT-011 — stub commands return applicationError
-    TEST_F(FocMotorCanBridgeTest, OnSetPidCurrent_ReturnsApplicationError)
+    TEST_F(FocMotorCanBridgeTest, OnSetPidCurrent_InTorqueMode_AcksSuccess)
     {
         ConstructFixture();
         ResetCaptures();
 
-        hal::Can::Message data;
-        data.resize(7, 0);
-        Dispatch(can::focSetPidCurrentId, data);
+        DispatchSetpoint(can::focSetPidCurrentId, 1000);
 
-        EXPECT_TRUE(categoryErrorSent);
-        EXPECT_EQ(lastCategoryErrorOriginCmd, can::focSetPidCurrentId);
-        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::applicationError);
         ASSERT_TRUE(ackSpy.last.has_value());
-        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::categoryError);
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
+        EXPECT_FALSE(categoryErrorSent);
     }
 
-    // REQ-INT-011
-    TEST_F(FocMotorCanBridgeTest, OnSetPidSpeed_ReturnsApplicationError)
+    TEST_F(FocMotorCanBridgeTest, OnSetPidSpeed_InSpeedMode_AcksSuccess)
     {
         ConstructFixture();
+        GivenModeSelected(can::FocMotorMode::speed);
         ResetCaptures();
 
-        Dispatch(can::focSetPidSpeedId, {});
+        DispatchSetpoint(can::focSetPidSpeedId, 100);
 
-        EXPECT_TRUE(categoryErrorSent);
-        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::applicationError);
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
+        EXPECT_FALSE(categoryErrorSent);
     }
 
-    // REQ-INT-011
-    TEST_F(FocMotorCanBridgeTest, OnSetPidPosition_ReturnsApplicationError)
+    TEST_F(FocMotorCanBridgeTest, OnSetPidPosition_InPositionMode_AcksSuccess)
     {
         ConstructFixture();
+        GivenModeSelected(can::FocMotorMode::position);
         ResetCaptures();
 
-        Dispatch(can::focSetPidPositionId, {});
+        DispatchSetpoint(can::focSetPidPositionId, 18);
 
-        EXPECT_TRUE(categoryErrorSent);
-        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::applicationError);
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
+        EXPECT_FALSE(categoryErrorSent);
     }
 
     // REQ-CM-001 — SelectControlMode transitions the active mode
@@ -495,61 +500,171 @@ namespace
         EXPECT_FALSE(selectResponseSent);
     }
 
-    // Remaining stub handlers — REQ-INT-011
-    TEST_F(FocMotorCanBridgeTest, OnIdentifyElectrical_ReturnsApplicationError)
+    TEST_F(FocMotorCanBridgeTest, OnIdentifyElectrical_BroadcastsParamsAndAcksSuccess)
     {
         ConstructFixture();
-        ResetCaptures();
 
+        EXPECT_CALL(electricalIdentMock, EstimateResistanceAndInductance(_, _))
+            .WillOnce(Invoke([](const services::ElectricalParametersIdentification::ResistanceAndInductanceConfig&,
+                               infra::Function<void(std::optional<foc::Ohm>, std::optional<foc::MilliHenry>)> done)
+                {
+                    done(foc::Ohm{ 0.5f }, foc::MilliHenry{ 1.0f });
+                }));
+        EXPECT_CALL(electricalIdentMock, EstimateNumberOfPolePairs(_, _))
+            .WillOnce(Invoke([](const services::ElectricalParametersIdentification::PolePairsConfig&,
+                               infra::Function<void(std::optional<std::size_t>)> done)
+                {
+                    done(std::size_t{ 4 });
+                }));
+
+        ResetCaptures();
+        Dispatch(can::focIdentifyElectricalId, {});
+
+        EXPECT_EQ(lastSentMsgType, can::focElectricalParamsResponseId);
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
+        EXPECT_FALSE(categoryErrorSent);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnIdentifyElectrical_FailedResistance_SendsCalibrationFailed)
+    {
+        ConstructFixture();
+
+        EXPECT_CALL(electricalIdentMock, EstimateResistanceAndInductance(_, _))
+            .WillOnce(Invoke([](const services::ElectricalParametersIdentification::ResistanceAndInductanceConfig&,
+                               infra::Function<void(std::optional<foc::Ohm>, std::optional<foc::MilliHenry>)> done)
+                {
+                    done(std::nullopt, std::nullopt);
+                }));
+
+        ResetCaptures();
         Dispatch(can::focIdentifyElectricalId, {});
 
         EXPECT_TRUE(categoryErrorSent);
-        EXPECT_EQ(lastCategoryErrorOriginCmd, can::focIdentifyElectricalId);
-        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::applicationError);
+        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::calibrationFailed);
     }
 
-    TEST_F(FocMotorCanBridgeTest, OnIdentifyMechanical_ReturnsApplicationError)
+    TEST_F(FocMotorCanBridgeTest, OnIdentifyMechanical_InReady_BroadcastsParamsAndAcksSuccess)
+    {
+        ConstructFixtureInReady();
+
+        EXPECT_CALL(mechIdentMock, EstimateFrictionAndInertia(_, _, _, _))
+            .WillOnce(Invoke([](const foc::NewtonMeter&, std::size_t,
+                               const services::MechanicalParametersIdentification::Config&,
+                               infra::Function<void(std::optional<foc::NewtonMeterSecondPerRadian>,
+                                   std::optional<foc::NewtonMeterSecondSquared>)> done)
+                {
+                    done(foc::NewtonMeterSecondPerRadian{ 0.001f }, foc::NewtonMeterSecondSquared{ 0.002f });
+                }));
+
+        ResetCaptures();
+        Dispatch(can::focIdentifyMechanicalId, {});
+
+        EXPECT_EQ(lastSentMsgType, can::focMechanicalParamsResponseId);
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
+        EXPECT_FALSE(categoryErrorSent);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnIdentifyMechanical_InIdle_RejectsInvalidState)
     {
         ConstructFixture();
         ResetCaptures();
 
         Dispatch(can::focIdentifyMechanicalId, {});
 
-        EXPECT_TRUE(categoryErrorSent);
-        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::applicationError);
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::invalidState);
+        EXPECT_FALSE(categoryErrorSent);
     }
 
-    TEST_F(FocMotorCanBridgeTest, OnRequestTelemetry_ReturnsApplicationError)
+    TEST_F(FocMotorCanBridgeTest, OnRequestTelemetry_InIdle_BroadcastsIdleStatus)
     {
         ConstructFixture();
         ResetCaptures();
 
         Dispatch(can::focRequestTelemetryId, {});
 
-        EXPECT_TRUE(categoryErrorSent);
-        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::applicationError);
+        EXPECT_EQ(lastSentMsgType, can::focTelemetryStatusResponseId);
+        ASSERT_GE(lastSentData.size(), 2u);
+        EXPECT_EQ(lastSentData[0], static_cast<uint8_t>(can::FocMotorState::idle));
+        EXPECT_EQ(lastSentData[1], static_cast<uint8_t>(can::FocFaultCode::none));
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
     }
 
-    TEST_F(FocMotorCanBridgeTest, OnSetEncoderResolution_ReturnsApplicationError)
+    TEST_F(FocMotorCanBridgeTest, OnRequestTelemetry_InEnabled_BroadcastsRunningStatus)
+    {
+        ConstructFixtureInReady();
+        Dispatch(can::focStartId, {});
+        ResetCaptures();
+
+        Dispatch(can::focRequestTelemetryId, {});
+
+        EXPECT_EQ(lastSentMsgType, can::focTelemetryStatusResponseId);
+        ASSERT_GE(lastSentData.size(), 2u);
+        EXPECT_EQ(lastSentData[0], static_cast<uint8_t>(can::FocMotorState::running));
+        EXPECT_EQ(lastSentData[1], static_cast<uint8_t>(can::FocFaultCode::none));
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnSetEncoderResolution_PersistsToNvmAndAcksSuccess)
+    {
+        ConstructFixture();
+
+        EXPECT_CALL(nvmMock, SaveConfig(_, _))
+            .WillOnce(Invoke([](const services::ConfigData&, infra::Function<void(services::NvmStatus)> done)
+                {
+                    done(services::NvmStatus::Ok);
+                }));
+
+        ResetCaptures();
+        DispatchUInt32Command(can::focSetEncoderResolutionId, 8000);
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
+        EXPECT_FALSE(categoryErrorSent);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnSetEncoderResolution_ZeroResolution_RejectsInvalidPayload)
     {
         ConstructFixture();
         ResetCaptures();
 
-        Dispatch(can::focSetEncoderResolutionId, {});
+        DispatchUInt32Command(can::focSetEncoderResolutionId, 0);
 
-        EXPECT_TRUE(categoryErrorSent);
-        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::applicationError);
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::invalidPayload);
+        EXPECT_FALSE(categoryErrorSent);
     }
 
-    TEST_F(FocMotorCanBridgeTest, OnConfigureTelemetryRate_ReturnsApplicationError)
+    TEST_F(FocMotorCanBridgeTest, OnConfigureTelemetryRate_PersistsToNvmAndAcksSuccess)
+    {
+        ConstructFixture();
+
+        EXPECT_CALL(nvmMock, SaveConfig(_, _))
+            .WillOnce(Invoke([](const services::ConfigData&, infra::Function<void(services::NvmStatus)> done)
+                {
+                    done(services::NvmStatus::Ok);
+                }));
+
+        ResetCaptures();
+        DispatchUInt32Command(can::focConfigureTelemetryRateId, 200);
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
+        EXPECT_FALSE(categoryErrorSent);
+    }
+
+    TEST_F(FocMotorCanBridgeTest, OnConfigureTelemetryRate_ZeroRate_RejectsInvalidPayload)
     {
         ConstructFixture();
         ResetCaptures();
 
-        Dispatch(can::focConfigureTelemetryRateId, {});
+        DispatchUInt32Command(can::focConfigureTelemetryRateId, 0);
 
-        EXPECT_TRUE(categoryErrorSent);
-        EXPECT_EQ(lastCategoryError, can::FocMotorCategoryError::applicationError);
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::invalidPayload);
+        EXPECT_FALSE(categoryErrorSent);
     }
 
     // REQ-INT-013 — BroadcastFault sends telemetry status frame with fault state
@@ -646,7 +761,7 @@ namespace
                 hal::Hertz{ 1000 },
                 lowPriorityInterruptMock });
 
-        bridge.emplace(*motorServer, *coordinator, inverterMock, tracer);
+        bridge.emplace(*motorServer, *coordinator, inverterMock, electricalIdentMock, &mechIdentMock, nvmMock, config, tracer);
         motorServer->SetAcknowledger(ackSpy);
         ExecuteAllActions();
     }

--- a/core/can/test/TestFocMotorCategoryServer.cpp
+++ b/core/can/test/TestFocMotorCategoryServer.cpp
@@ -46,14 +46,14 @@ namespace
         MOCK_METHOD(void, OnSetTorqueSetpoint, (foc::Ampere, (const infra::Function<void()>&)), (override));
         MOCK_METHOD(void, OnSetSpeedSetpoint, (foc::RadiansPerSecond, (const infra::Function<void()>&)), (override));
         MOCK_METHOD(void, OnSetPositionSetpoint, (foc::Radians, (const infra::Function<void()>&)), (override));
-        MOCK_METHOD(void, OnSetPidCurrent, (const infra::Function<void()>&), (override));
-        MOCK_METHOD(void, OnSetPidSpeed, (const infra::Function<void()>&), (override));
-        MOCK_METHOD(void, OnSetPidPosition, (const infra::Function<void()>&), (override));
+        MOCK_METHOD(void, OnSetPidCurrent, (float, (const infra::Function<void()>&)), (override));
+        MOCK_METHOD(void, OnSetPidSpeed, (float, (const infra::Function<void()>&)), (override));
+        MOCK_METHOD(void, OnSetPidPosition, (float, (const infra::Function<void()>&)), (override));
         MOCK_METHOD(void, OnIdentifyElectrical, (const infra::Function<void()>&), (override));
         MOCK_METHOD(void, OnIdentifyMechanical, (const infra::Function<void()>&), (override));
         MOCK_METHOD(void, OnRequestTelemetry, (const infra::Function<void()>&), (override));
-        MOCK_METHOD(void, OnSetEncoderResolution, (const infra::Function<void()>&), (override));
-        MOCK_METHOD(void, OnConfigureTelemetryRate, (const infra::Function<void()>&), (override));
+        MOCK_METHOD(void, OnSetEncoderResolution, (uint32_t, (const infra::Function<void()>&)), (override));
+        MOCK_METHOD(void, OnConfigureTelemetryRate, (uint32_t, (const infra::Function<void()>&)), (override));
     };
 
     class FocMotorCategoryServerTest : public Test
@@ -98,6 +98,14 @@ namespace
             hal::Can::Message msg;
             msg.resize(2, 0);
             msg[1] = static_cast<uint8_t>(mode);
+            return msg;
+        }
+
+        hal::Can::Message MakeUInt32Payload(uint32_t value)
+        {
+            hal::Can::Message msg;
+            msg.resize(5, 0);
+            services::CanFrameCodec::WriteUInt32(msg, 1, value);
             return msg;
         }
 
@@ -241,10 +249,15 @@ namespace
         EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::notImplemented);
     }
 
-    TEST_F(FocMotorCategoryServerTest, HandleSetPidCurrent_InvokesStubObserver)
+    TEST_F(FocMotorCategoryServerTest, HandleSetPidCurrent_ParsesBandwidthAndInvokesObserver)
     {
-        EXPECT_CALL(observer, OnSetPidCurrent(_));
-        server.HandleMessage(can::focSetPidCurrentId, MakePayload(1));
+        EXPECT_CALL(observer, OnSetPidCurrent(_, _))
+            .WillOnce(Invoke([](float, const infra::Function<void()>& done) { done(); }));
+
+        server.HandleMessage(can::focSetPidCurrentId, MakeSetpointPayload(1000));
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
     }
 
     TEST_F(FocMotorCategoryServerTest, HandleClearFault_InvokesOnClearFaultObserver)
@@ -343,23 +356,23 @@ namespace
         EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
     }
 
-    TEST_F(FocMotorCategoryServerTest, HandleSetEncoderResolution_InvokesObserver)
+    TEST_F(FocMotorCategoryServerTest, HandleSetEncoderResolution_ParsesResolutionAndInvokesObserver)
     {
-        EXPECT_CALL(observer, OnSetEncoderResolution(_))
-            .WillOnce(Invoke([](const infra::Function<void()>& done) { done(); }));
+        EXPECT_CALL(observer, OnSetEncoderResolution(4000u, _))
+            .WillOnce(Invoke([](uint32_t, const infra::Function<void()>& done) { done(); }));
 
-        server.HandleMessage(can::focSetEncoderResolutionId, MakePayload(1));
+        server.HandleMessage(can::focSetEncoderResolutionId, MakeUInt32Payload(4000));
 
         ASSERT_TRUE(ackSpy.last.has_value());
         EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
     }
 
-    TEST_F(FocMotorCategoryServerTest, HandleConfigureTelemetryRate_InvokesObserver)
+    TEST_F(FocMotorCategoryServerTest, HandleConfigureTelemetryRate_ParsesRateAndInvokesObserver)
     {
-        EXPECT_CALL(observer, OnConfigureTelemetryRate(_))
-            .WillOnce(Invoke([](const infra::Function<void()>& done) { done(); }));
+        EXPECT_CALL(observer, OnConfigureTelemetryRate(100u, _))
+            .WillOnce(Invoke([](uint32_t, const infra::Function<void()>& done) { done(); }));
 
-        server.HandleMessage(can::focConfigureTelemetryRateId, MakePayload(1));
+        server.HandleMessage(can::focConfigureTelemetryRateId, MakeUInt32Payload(100));
 
         ASSERT_TRUE(ackSpy.last.has_value());
         EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);

--- a/core/can/test/TestFocMotorCategoryServer.cpp
+++ b/core/can/test/TestFocMotorCategoryServer.cpp
@@ -356,6 +356,68 @@ namespace
         EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
     }
 
+    TEST_F(FocMotorCategoryServerTest, HandleSetPidSpeed_ParsesBandwidthAndInvokesObserver)
+    {
+        EXPECT_CALL(observer, OnSetPidSpeed(_, _))
+            .WillOnce(Invoke([](float, const infra::Function<void()>& done) { done(); }));
+
+        server.HandleMessage(can::focSetPidSpeedId, MakeSetpointPayload(100));
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
+    }
+
+    TEST_F(FocMotorCategoryServerTest, HandleSetPidPosition_ParsesBandwidthAndInvokesObserver)
+    {
+        EXPECT_CALL(observer, OnSetPidPosition(_, _))
+            .WillOnce(Invoke([](float, const infra::Function<void()>& done) { done(); }));
+
+        server.HandleMessage(can::focSetPidPositionId, MakeSetpointPayload(18));
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::success);
+    }
+
+    TEST_F(FocMotorCategoryServerTest, HandleSetPidCurrent_ShortPayload_AcksInvalidPayload)
+    {
+        server.HandleMessage(can::focSetPidCurrentId, MakePayload(1));
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::invalidPayload);
+    }
+
+    TEST_F(FocMotorCategoryServerTest, HandleSetPidSpeed_ShortPayload_AcksInvalidPayload)
+    {
+        server.HandleMessage(can::focSetPidSpeedId, MakePayload(1));
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::invalidPayload);
+    }
+
+    TEST_F(FocMotorCategoryServerTest, HandleSetPidPosition_ShortPayload_AcksInvalidPayload)
+    {
+        server.HandleMessage(can::focSetPidPositionId, MakePayload(1));
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::invalidPayload);
+    }
+
+    TEST_F(FocMotorCategoryServerTest, HandleSetEncoderResolution_ShortPayload_AcksInvalidPayload)
+    {
+        server.HandleMessage(can::focSetEncoderResolutionId, MakePayload(1));
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::invalidPayload);
+    }
+
+    TEST_F(FocMotorCategoryServerTest, HandleConfigureTelemetryRate_ShortPayload_AcksInvalidPayload)
+    {
+        server.HandleMessage(can::focConfigureTelemetryRateId, MakePayload(1));
+
+        ASSERT_TRUE(ackSpy.last.has_value());
+        EXPECT_EQ(ackSpy.last->status, services::CanAckStatus::invalidPayload);
+    }
+
     TEST_F(FocMotorCategoryServerTest, HandleSetEncoderResolution_ParsesResolutionAndInvokesObserver)
     {
         EXPECT_CALL(observer, OnSetEncoderResolution(4000u, _))

--- a/documentation/design/service-can.md
+++ b/documentation/design/service-can.md
@@ -252,7 +252,7 @@ graph LR
 
 ## Open Questions
 
-| # | Question                                                           | Resolution                                                                                   | Status   |
+| # | Question                                                         | Resolution                                                                                   | Status   |
 |---|------------------------------------------------------------------|----------------------------------------------------------------------------------------------|----------|
 | 1 | Implement telemetry push (BroadcastFaultStatus, periodic status) | On-demand via `OnRequestTelemetry`; periodic timer deferred                                  | resolved |
 | 2 | PID gain commands                                                | Accepted: kp field mapped to loop bandwidth via `TrySet*Bandwidth`                           | resolved |

--- a/documentation/design/service-can.md
+++ b/documentation/design/service-can.md
@@ -241,7 +241,7 @@ graph LR
 |-------------------------|------------------------------------------------------------------------------------------------------------|
 | No heap                 | All objects are value members or statically allocated; `infra::Function` for callbacks                     |
 | One observer per server | `CanCategoryServer` uses `infra::Subject<Observer>` — only one bridge may attach at a time                 |
-| Setpoint range          | Torque: bounded by inverter `MaxCurrentSupported`; speed: 1000 rad/s; position: ±2π rad                   |
+| Setpoint range          | Torque: bounded by inverter `MaxCurrentSupported`; speed: 1000 rad/s; position: ±2π rad                    |
 | Sequence byte           | Server handlers always skip the first byte (sequence number) before reading payload fields                 |
 | Ident re-entrancy       | A second identification command while one is in-flight returns `busy` via `SendCategoryError`              |
 | NVM re-entrancy         | A second config-persist command while one is in-flight returns `busy` via `SendCategoryError`              |
@@ -252,8 +252,8 @@ graph LR
 
 ## Open Questions
 
-| # | Question                                                           | Resolution                                                                                  | Status   |
-|---|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------|----------|
-| 1 | Implement telemetry push (BroadcastFaultStatus, periodic status)   | On-demand via `OnRequestTelemetry`; periodic timer deferred                                 | resolved |
-| 2 | PID gain commands                                                  | Accepted: kp field mapped to loop bandwidth via `TrySet*Bandwidth`                          | resolved |
-| 3 | Mechanical identification via CAN                                  | Delegated to injected `MechanicalParametersIdentification*`; nullable for targets lacking it | resolved |
+| # | Question                                                         | Resolution                                                                                   | Status   |
+|---|------------------------------------------------------------------|----------------------------------------------------------------------------------------------|----------|
+| 1 | Implement telemetry push (BroadcastFaultStatus, periodic status) | On-demand via `OnRequestTelemetry`; periodic timer deferred                                  | resolved |
+| 2 | PID gain commands                                                | Accepted: kp field mapped to loop bandwidth via `TrySet*Bandwidth`                           | resolved |
+| 3 | Mechanical identification via CAN                                | Delegated to injected `MechanicalParametersIdentification*`; nullable for targets lacking it | resolved |

--- a/documentation/design/service-can.md
+++ b/documentation/design/service-can.md
@@ -35,7 +35,9 @@ date: 2026-08-21
 - Bridging the server category to `ControlModeStateMachine`, translating motor control commands into state machine transitions.
 - Providing a user-facing client API that composes the protocol client, transport, and category client into a single object for use by host-side tools and SIL tests.
 - Applying tracing decorators at every layer boundary so all CAN frames and protocol lifecycle events are observable.
-- Immediately returning `applicationError` for commands not yet implemented in this iteration.
+- Delegating identification commands to `ElectricalParametersIdentification` and `MechanicalParametersIdentification` services and broadcasting results via response frames.
+- Persisting encoder resolution and telemetry rate changes to `NonVolatileMemory`.
+- Broadcasting on-demand telemetry status frames in response to `RequestTelemetry`.
 
 **Is NOT responsible for:**
 - The CAN protocol framing, sequence validation, or ACK dispatch — those belong to `can-lite` core.
@@ -72,7 +74,11 @@ The observer interface provides callbacks for:
 - `OnStart`, `OnStop`, `OnClearFault`, `OnEmergencyStop` — lifecycle commands with a `CanAckStatus` result callback.
 - `OnSelectControlMode` — takes a `FocMotorMode` and a result callback.
 - `OnSetTorqueSetpoint`, `OnSetSpeedSetpoint`, `OnSetPositionSetpoint` — take a typed unit quantity and a completion callback.
-- All other commands (`OnSetPidCurrent`, `OnSetPidSpeed`, `OnSetPidPosition`, `OnIdentifyElectrical`, `OnIdentifyMechanical`, `OnRequestTelemetry`, `OnSetEncoderResolution`, `OnConfigureTelemetryRate`) — the default bridge implementation returns `applicationError` immediately.
+- `OnSetPidCurrent`, `OnSetPidSpeed`, `OnSetPidPosition` — receive a bandwidth parameter parsed from the CAN frame and forward to the corresponding `TrySet*Bandwidth` on `ControlModeStateMachine`.
+- `OnIdentifyElectrical` — delegates to `ElectricalParametersIdentification`; on success broadcasts `focElectricalParamsResponseId` with resistance, inductance, and pole-pair count.
+- `OnIdentifyMechanical` — requires Ready state; delegates to `MechanicalParametersIdentification`; on success broadcasts `focMechanicalParamsResponseId` with friction and inertia.
+- `OnRequestTelemetry` — broadcasts current state and fault code via `focTelemetryStatusResponseId`.
+- `OnSetEncoderResolution`, `OnConfigureTelemetryRate` — validate payload, update and persist `ConfigData` via `NonVolatileMemory`.
 
 ### Part C — FocMotorCategoryClient
 
@@ -90,7 +96,10 @@ Implements the `FocMotorCategoryServerObserver` interface. Holds references to `
 - `OnEmergencyStop` → `CmdEmergencyStop()`.
 - `OnSelectControlMode` → `Select(mode, onDone)`; the result callback sends the mode response or a category error.
 - `OnSetTorqueSetpoint`, `OnSetSpeedSetpoint`, `OnSetPositionSetpoint` → validate mode and range, then delegate to `TrySet*` on the state machine.
-- All stub commands → `SendCategoryError(commandId, applicationError)`.
+- PID bandwidth commands → `TrySet*Bandwidth(bandwidth)` on the state machine; `invalidPayload` if rejected.
+- Identification commands → delegate to the injected identification services; broadcast parameter response frames on success; `calibrationFailed` on estimation failure; `busy` if a prior identification is in progress.
+- `OnRequestTelemetry` → broadcast current state and fault code via `focTelemetryStatusResponseId`; always succeeds.
+- `OnSetEncoderResolution` / `OnConfigureTelemetryRate` → persist to `NonVolatileMemory`; `persistenceFailed` on write error; `busy` if a prior NVM save is in flight.
 
 The bridge validates that the correct control mode is active before accepting a setpoint command. An out-of-range setpoint results in `invalidPayload`. A mode mismatch results in `categoryError/modeMismatch`.
 
@@ -228,20 +237,23 @@ graph LR
 
 ## Constraints & Limitations
 
-| Constraint              | Value / Description                                                                        |
-|-------------------------|--------------------------------------------------------------------------------------------|
-| Stub command policy     | Commands not yet implemented return `applicationError` via `SendCategoryError` immediately |
-| No heap                 | All objects are value members or statically allocated; `infra::Function` for callbacks     |
-| One observer per server | `CanCategoryServer` uses `infra::Subject<Observer>` — only one bridge may attach at a time |
-| Setpoint range          | Torque: bounded by inverter `MaxCurrentSupported`; speed: 1000 rad/s; position: ±2π rad    |
-| Sequence byte           | Server handlers always skip the first byte (sequence number) before reading payload fields |
+| Constraint              | Value / Description                                                                                        |
+|-------------------------|------------------------------------------------------------------------------------------------------------|
+| No heap                 | All objects are value members or statically allocated; `infra::Function` for callbacks                     |
+| One observer per server | `CanCategoryServer` uses `infra::Subject<Observer>` — only one bridge may attach at a time                 |
+| Setpoint range          | Torque: bounded by inverter `MaxCurrentSupported`; speed: 1000 rad/s; position: ±2π rad                   |
+| Sequence byte           | Server handlers always skip the first byte (sequence number) before reading payload fields                 |
+| Ident re-entrancy       | A second identification command while one is in-flight returns `busy` via `SendCategoryError`              |
+| NVM re-entrancy         | A second config-persist command while one is in-flight returns `busy` via `SendCategoryError`              |
+| Mechanical ident        | `mechIdent` is optional (nullable pointer); if absent, `OnIdentifyMechanical` returns `notImplemented`     |
+| Telemetry speed/pos     | `focTelemetryStatusResponseId` frames encode zero for speed and position (live readings not yet available) |
 
 ---
 
 ## Open Questions
 
-| # | Question                                                         | Options                                        | Status |
-|---|------------------------------------------------------------------|------------------------------------------------|--------|
-| 1 | Implement telemetry push (BroadcastFaultStatus, periodic status) | Periodic timer vs on-demand vs fault-triggered | open   |
-| 2 | PID gain commands                                                | Accept and persist vs remain applicationError  | open   |
-| 3 | Mechanical identification via CAN                                | Delegate to existing service vs stub           | open   |
+| # | Question                                                           | Resolution                                                                                  | Status   |
+|---|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------|----------|
+| 1 | Implement telemetry push (BroadcastFaultStatus, periodic status)   | On-demand via `OnRequestTelemetry`; periodic timer deferred                                 | resolved |
+| 2 | PID gain commands                                                  | Accepted: kp field mapped to loop bandwidth via `TrySet*Bandwidth`                          | resolved |
+| 3 | Mechanical identification via CAN                                  | Delegated to injected `MechanicalParametersIdentification*`; nullable for targets lacking it | resolved |

--- a/documentation/design/service-can.md
+++ b/documentation/design/service-can.md
@@ -252,7 +252,7 @@ graph LR
 
 ## Open Questions
 
-| # | Question                                                         | Resolution                                                                                   | Status   |
+| # | Question                                                           | Resolution                                                                                   | Status   |
 |---|------------------------------------------------------------------|----------------------------------------------------------------------------------------------|----------|
 | 1 | Implement telemetry push (BroadcastFaultStatus, periodic status) | On-demand via `OnRequestTelemetry`; periodic timer deferred                                  | resolved |
 | 2 | PID gain commands                                                | Accepted: kp field mapped to loop bandwidth via `TrySet*Bandwidth`                           | resolved |

--- a/documentation/requirements/integration/can-state-machine.yaml
+++ b/documentation/requirements/integration/can-state-machine.yaml
@@ -72,12 +72,23 @@
     frame without modification.
 
 - id: REQ-INT-011
-  title: Stub commands return applicationError
+  title: Deferred commands are fully implemented
   shall: >
-    FocMotorCanBridge shall respond with a category error of type applicationError for
-    any command whose implementation is deferred to a future iteration. The error frame
-    shall be sent synchronously within the handler, before returning. No state machine
-    transition shall occur for a stub command.
+    FocMotorCanBridge shall implement all previously deferred commands.
+    OnSetPidCurrent, OnSetPidSpeed, and OnSetPidPosition shall parse the bandwidth
+    field from the CAN frame and forward it to the corresponding TrySet*Bandwidth
+    method on ControlModeStateMachine, responding with success or invalidPayload.
+    OnIdentifyElectrical shall delegate to ElectricalParametersIdentification,
+    broadcast the result via focElectricalParamsResponseId, and acknowledge success,
+    or send calibrationFailed on estimation failure.
+    OnIdentifyMechanical shall require the state machine to be in Ready state, delegate
+    to MechanicalParametersIdentification, broadcast via focMechanicalParamsResponseId,
+    and acknowledge success; it shall respond invalidState if not in Ready, and
+    notImplemented if no MechanicalParametersIdentification service is available.
+    OnRequestTelemetry shall broadcast the current motor state and fault code via
+    focTelemetryStatusResponseId and acknowledge success.
+    OnSetEncoderResolution and OnConfigureTelemetryRate shall validate their payloads,
+    persist to NonVolatileMemory, and acknowledge success or persistenceFailed.
 
 - id: REQ-INT-012
   title: CAN frames and protocol events are observable via tracing decorators

--- a/integration_tests/software_in_the_loop/support/ControlModeCoordinationFixture.cpp
+++ b/integration_tests/software_in_the_loop/support/ControlModeCoordinationFixture.cpp
@@ -124,7 +124,7 @@ namespace integration
         canProtocolServer.emplace(transportCanMock, services::CanProtocolServer::Config{ .nodeId = 1 });
         motorCategoryServer.emplace(canProtocolServer->Transport());
         canProtocolServer->RegisterCategory(*motorCategoryServer);
-        motorBridge.emplace(*motorCategoryServer, *coordinator, platformFactory, electricalIdentMock, &mechIdentMock, nvm, services::MakeDefaultConfigData(), tracer);
+        motorBridge.emplace(*motorCategoryServer, *coordinator, platformFactory, electricalIdentMock, &mechIdentMock, foc::NewtonMeter{ 0.1f }, nvm, services::MakeDefaultConfigData(), tracer);
     }
 
     void ControlModeCoordinationFixture::DispatchToMotor(uint8_t messageType, const hal::Can::Message& data)

--- a/integration_tests/software_in_the_loop/support/ControlModeCoordinationFixture.cpp
+++ b/integration_tests/software_in_the_loop/support/ControlModeCoordinationFixture.cpp
@@ -124,7 +124,7 @@ namespace integration
         canProtocolServer.emplace(transportCanMock, services::CanProtocolServer::Config{ .nodeId = 1 });
         motorCategoryServer.emplace(canProtocolServer->Transport());
         canProtocolServer->RegisterCategory(*motorCategoryServer);
-        motorBridge.emplace(*motorCategoryServer, *coordinator, platformFactory, tracer);
+        motorBridge.emplace(*motorCategoryServer, *coordinator, platformFactory, electricalIdentMock, &mechIdentMock, nvm, services::MakeDefaultConfigData(), tracer);
     }
 
     void ControlModeCoordinationFixture::DispatchToMotor(uint8_t messageType, const hal::Can::Message& data)

--- a/integration_tests/software_in_the_loop/support/FocMotorStateMachineBridge.cpp
+++ b/integration_tests/software_in_the_loop/support/FocMotorStateMachineBridge.cpp
@@ -44,13 +44,13 @@ namespace integration
     void FocMotorStateMachineBridge::OnSetPositionSetpoint(foc::Radians, const infra::Function<void()>&)
     {}
 
-    void FocMotorStateMachineBridge::OnSetPidCurrent(const infra::Function<void()>&)
+    void FocMotorStateMachineBridge::OnSetPidCurrent(float, const infra::Function<void()>&)
     {}
 
-    void FocMotorStateMachineBridge::OnSetPidSpeed(const infra::Function<void()>&)
+    void FocMotorStateMachineBridge::OnSetPidSpeed(float, const infra::Function<void()>&)
     {}
 
-    void FocMotorStateMachineBridge::OnSetPidPosition(const infra::Function<void()>&)
+    void FocMotorStateMachineBridge::OnSetPidPosition(float, const infra::Function<void()>&)
     {}
 
     void FocMotorStateMachineBridge::OnIdentifyElectrical(const infra::Function<void()>&)
@@ -62,9 +62,9 @@ namespace integration
     void FocMotorStateMachineBridge::OnRequestTelemetry(const infra::Function<void()>&)
     {}
 
-    void FocMotorStateMachineBridge::OnSetEncoderResolution(const infra::Function<void()>&)
+    void FocMotorStateMachineBridge::OnSetEncoderResolution(uint32_t, const infra::Function<void()>&)
     {}
 
-    void FocMotorStateMachineBridge::OnConfigureTelemetryRate(const infra::Function<void()>&)
+    void FocMotorStateMachineBridge::OnConfigureTelemetryRate(uint32_t, const infra::Function<void()>&)
     {}
 }

--- a/integration_tests/software_in_the_loop/support/FocMotorStateMachineBridge.hpp
+++ b/integration_tests/software_in_the_loop/support/FocMotorStateMachineBridge.hpp
@@ -22,14 +22,14 @@ namespace integration
         void OnSetSpeedSetpoint(foc::RadiansPerSecond, const infra::Function<void()>&) override;
         void OnSetPositionSetpoint(foc::Radians, const infra::Function<void()>&) override;
 
-        void OnSetPidCurrent(const infra::Function<void()>&) override;
-        void OnSetPidSpeed(const infra::Function<void()>&) override;
-        void OnSetPidPosition(const infra::Function<void()>&) override;
+        void OnSetPidCurrent(float bandwidth, const infra::Function<void()>&) override;
+        void OnSetPidSpeed(float bandwidth, const infra::Function<void()>&) override;
+        void OnSetPidPosition(float bandwidth, const infra::Function<void()>&) override;
         void OnIdentifyElectrical(const infra::Function<void()>&) override;
         void OnIdentifyMechanical(const infra::Function<void()>&) override;
         void OnRequestTelemetry(const infra::Function<void()>&) override;
-        void OnSetEncoderResolution(const infra::Function<void()>&) override;
-        void OnConfigureTelemetryRate(const infra::Function<void()>&) override;
+        void OnSetEncoderResolution(uint32_t resolution, const infra::Function<void()>&) override;
+        void OnConfigureTelemetryRate(uint32_t rateHz, const infra::Function<void()>&) override;
 
     private:
         state_machine::FocStateMachineBase& stateMachine;

--- a/targets/sync_foc_sensored/main/instantiations/Logic.cpp
+++ b/targets/sync_foc_sensored/main/instantiations/Logic.cpp
@@ -41,7 +41,7 @@ namespace application
                         this->hardware.MaxCurrentSupported(),
                         this->hardware.BaseFrequency(),
                         this->hardware.LowPriorityInterrupt() });
-                canBridge.emplace(*motorCanServer, *controlMode, this->hardware, electricalIdent, nullptr, nvm, configData, this->hardware.Tracer());
+                canBridge.emplace(*motorCanServer, *controlMode, this->hardware, electricalIdent, nullptr, foc::NewtonMeter{ motorTorqueConstantNm }, nvm, configData, this->hardware.Tracer());
                 platformFaultNotifier.RegisterSecondary([this](state_machine::FaultCode code)
                     {
                         infra::EventDispatcher::Instance().Schedule([this, code]()

--- a/targets/sync_foc_sensored/main/instantiations/Logic.cpp
+++ b/targets/sync_foc_sensored/main/instantiations/Logic.cpp
@@ -41,7 +41,7 @@ namespace application
                         this->hardware.MaxCurrentSupported(),
                         this->hardware.BaseFrequency(),
                         this->hardware.LowPriorityInterrupt() });
-                canBridge.emplace(*motorCanServer, *controlMode, this->hardware, this->hardware.Tracer());
+                canBridge.emplace(*motorCanServer, *controlMode, this->hardware, electricalIdent, nullptr, nvm, configData, this->hardware.Tracer());
                 platformFaultNotifier.RegisterSecondary([this](state_machine::FaultCode code)
                     {
                         infra::EventDispatcher::Instance().Schedule([this, code]()

--- a/targets/sync_foc_sensored/main/instantiations/Logic.hpp
+++ b/targets/sync_foc_sensored/main/instantiations/Logic.hpp
@@ -34,6 +34,7 @@ namespace application
         static constexpr uint32_t controlLoopFrequencyHz = 20000;
         static constexpr uint32_t pwmDeadTimeNs = 500;
         static constexpr float motorFluxLinkageWb = 0.007f;
+        static constexpr float motorTorqueConstantNm = 0.1f;
 
         using ControlMode = state_machine::ControlModeStateMachine;
 


### PR DESCRIPTION
Closes #240. Implements the eight commands that were intentionally left as stubs returning applicationError in the initial CAN service layer iteration.

PID bandwidth setters parse a bandwidth value from the CAN frame and forward it to TrySet*Bandwidth on ControlModeStateMachine. Identification commands delegate to the injected ElectricalParametersIdentification and MechanicalParametersIdentification services, broadcasting results via focElectricalParamsResponseId and focMechanicalParamsResponseId. MechanicalParametersIdentification is optional (nullable pointer) so the production target, which has no externally accessible mechIdent service, passes nullptr and receives notImplemented. OnRequestTelemetry broadcasts the current state and fault code via focTelemetryStatusResponseId. OnSetEncoderResolution and OnConfigureTelemetryRate validate and persist changes to NonVolatileMemory. Both NVM and identification paths guard against re-entrancy with a busy response.