### PR TITLE
fix(docs): copy TikZ SVGs to site and rewrite paths for HTML output

### DIFF
--- a/scripts/build-foc-booklet.py
+++ b/scripts/build-foc-booklet.py
@@ -520,6 +520,16 @@ def render_site(chapters, skip_diagrams, pdf_available=True):
             shutil.rmtree(dest)
         shutil.copytree(DIAGRAMS_DIR, dest)
 
+    tikz_img_src = TIKZ_DIR / "images"
+    if tikz_img_src.is_dir():
+        tikz_img_dest = SITE_DIR / "tikz-images"
+        if tikz_img_dest.exists():
+            shutil.rmtree(tikz_img_dest)
+        shutil.copytree(
+            tikz_img_src, tikz_img_dest,
+            ignore=shutil.ignore_patterns("*.stamp", ".gitkeep", ".gitignore"),
+        )
+
     status = 0
     fragments = BUILD_DIR / "fragments"
     fragments.mkdir(parents=True, exist_ok=True)
@@ -529,6 +539,11 @@ def render_site(chapters, skip_diagrams, pdf_available=True):
         markdown = re.sub(
             rf"!\[([^\]]*)\]\({re.escape(str(DIAGRAMS_DIR))}/",
             r"![\1](diagrams/",
+            markdown,
+        )
+        markdown = re.sub(
+            rf"!\[([^\]]*)\]\({re.escape(str(tikz_img_src))}/([^)]+)\)",
+            r"![\1](tikz-images/\2)",
             markdown,
         )
         markdown = re.sub(r"\A#\s+.+?\n", "", markdown, count=1)

--- a/scripts/build-foc-booklet.py
+++ b/scripts/build-foc-booklet.py
@@ -523,12 +523,9 @@ def render_site(chapters, skip_diagrams, pdf_available=True):
     tikz_img_src = TIKZ_DIR / "images"
     if tikz_img_src.is_dir():
         tikz_img_dest = SITE_DIR / "tikz-images"
-        if tikz_img_dest.exists():
-            shutil.rmtree(tikz_img_dest)
-        shutil.copytree(
-            tikz_img_src, tikz_img_dest,
-            ignore=shutil.ignore_patterns("*.stamp", ".gitkeep", ".gitignore"),
-        )
+        tikz_img_dest.mkdir(parents=True, exist_ok=True)
+        for svg in tikz_img_src.glob("*.svg"):
+            shutil.copyfile(svg, tikz_img_dest / svg.name)
 
     status = 0
     fragments = BUILD_DIR / "fragments"


### PR DESCRIPTION
Pre-committed SVGs in documentation/tikz/images/ were being converted to absolute filesystem paths by _absolute_images() and then never rewritten for the HTML build, causing broken image icons on GitHub Pages.

In render_site(), mirror the existing DIAGRAMS_DIR pattern:
- Copy documentation/tikz/images/*.svg to site/tikz-images/ (excluding stamps and gitkeep artefacts).
- Rewrite absolute tikz/images/... paths to tikz-images/filename.svg so the browser can resolve them from the served site root.