### PR TITLE
fix: PWM bootstrap and no-sample watchdog for R/L identification

### DIFF
--- a/core/services/electrical_system_ident/ResistanceEstimator.cpp
+++ b/core/services/electrical_system_ident/ResistanceEstimator.cpp
@@ -36,8 +36,11 @@ namespace services
         this->onDone = onDone;
         currentSamples.clear();
         filteredSamples.clear();
+        StartSettlePhase();
+    }
 
-        // Apply test voltage immediately so the settle timer gives current time to reach V/R.
+    void ResistanceEstimator::StartSettlePhase()
+    {
         driver.PhaseCurrentsReady(samplingFrequency, [this](auto currents)
             {
                 if (!this->onDone)
@@ -47,41 +50,51 @@ namespace services
                     FailMeasurement();
             });
         driver.ThreePhasePwmOutput(foc::PhasePwmDutyCycles{
-            hal::Percent{ config.testVoltagePercent.Value() },
+            hal::Percent{ activeConfig.testVoltagePercent.Value() },
             hal::Percent{ neutralDuty },
             hal::Percent{ neutralDuty } });
 
-        settleTimer.Start(config.settleTime, [this]()
+        settleTimer.Start(activeConfig.settleTime, [this]()
             {
-                noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
-                    {
-                        FailMeasurement();
-                    });
-                driver.PhaseCurrentsReady(samplingFrequency, [this](auto currents)
-                    {
-                        if (!this->onDone)
-                            return;
-
-                        noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
-                            {
-                                FailMeasurement();
-                            });
-
-                        if (ExceedsInjectionLimit(currents, driver.MaxCurrentSupported()))
-                        {
-                            FailMeasurement();
-                            return;
-                        }
-
-                        currentSamples.push_back(currents.a.Value());
-
-                        if (currentSamples.full())
-                            filteredSamples.push_back(AverageAndRemoveFront(currentSamples));
-
-                        if (filteredSamples.full())
-                            OnMeasurementComplete();
-                    });
+                StartMeasurementPhase();
             });
+    }
+
+    void ResistanceEstimator::StartMeasurementPhase()
+    {
+        noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
+            {
+                FailMeasurement();
+            });
+        driver.PhaseCurrentsReady(samplingFrequency, [this](auto currents)
+            {
+                OnMeasurementSample(currents);
+            });
+    }
+
+    void ResistanceEstimator::OnMeasurementSample(foc::PhaseCurrents currents)
+    {
+        if (!onDone)
+            return;
+
+        noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
+            {
+                FailMeasurement();
+            });
+
+        if (ExceedsInjectionLimit(currents, driver.MaxCurrentSupported()))
+        {
+            FailMeasurement();
+            return;
+        }
+
+        currentSamples.push_back(currents.a.Value());
+
+        if (currentSamples.full())
+            filteredSamples.push_back(AverageAndRemoveFront(currentSamples));
+
+        if (filteredSamples.full())
+            OnMeasurementComplete();
     }
 
     void ResistanceEstimator::Abort()

--- a/core/services/electrical_system_ident/ResistanceEstimator.cpp
+++ b/core/services/electrical_system_ident/ResistanceEstimator.cpp
@@ -30,6 +30,14 @@ namespace services
         , vdc(vdc)
     {}
 
+    ResistanceEstimator::~ResistanceEstimator()
+    {
+        settleTimer.Cancel();
+        noSampleTimer.Cancel();
+        if (onDone)
+            driver.Stop();
+    }
+
     void ResistanceEstimator::Start(const Config& config, const infra::Function<void(Result)>& onDone)
     {
         activeConfig = config;
@@ -46,6 +54,11 @@ namespace services
                 if (!this->onDone)
                     return;
 
+                noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
+                    {
+                        FailMeasurement();
+                    });
+
                 if (ExceedsInjectionLimit(currents, driver.MaxCurrentSupported()))
                     FailMeasurement();
             });
@@ -54,6 +67,10 @@ namespace services
             hal::Percent{ neutralDuty },
             hal::Percent{ neutralDuty } });
 
+        noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
+            {
+                FailMeasurement();
+            });
         settleTimer.Start(activeConfig.settleTime, [this]()
             {
                 StartMeasurementPhase();

--- a/core/services/electrical_system_ident/ResistanceEstimator.cpp
+++ b/core/services/electrical_system_ident/ResistanceEstimator.cpp
@@ -53,10 +53,19 @@ namespace services
 
         settleTimer.Start(config.settleTime, [this]()
             {
+                noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
+                    {
+                        FailMeasurement();
+                    });
                 driver.PhaseCurrentsReady(samplingFrequency, [this](auto currents)
                     {
                         if (!this->onDone)
                             return;
+
+                        noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
+                            {
+                                FailMeasurement();
+                            });
 
                         if (ExceedsInjectionLimit(currents, driver.MaxCurrentSupported()))
                         {
@@ -81,6 +90,7 @@ namespace services
             return;
 
         settleTimer.Cancel();
+        noSampleTimer.Cancel();
         driver.Stop();
         onDone = nullptr;
     }
@@ -88,6 +98,7 @@ namespace services
     void ResistanceEstimator::FailMeasurement()
     {
         settleTimer.Cancel();
+        noSampleTimer.Cancel();
         driver.Stop();
 
         if (onDone)
@@ -96,6 +107,7 @@ namespace services
 
     void ResistanceEstimator::OnMeasurementComplete()
     {
+        noSampleTimer.Cancel();
         driver.Stop();
 
         const float steadyStateCurrent = GetSteadyStateCurrent(filteredSamples);

--- a/core/services/electrical_system_ident/ResistanceEstimator.hpp
+++ b/core/services/electrical_system_ident/ResistanceEstimator.hpp
@@ -28,6 +28,7 @@ namespace services
         };
 
         ResistanceEstimator(drivers::ThreePhaseInverter& driver, foc::Volts vdc);
+        ~ResistanceEstimator();
 
         void Start(const Config& config, const infra::Function<void(Result)>& onDone);
 

--- a/core/services/electrical_system_ident/ResistanceEstimator.hpp
+++ b/core/services/electrical_system_ident/ResistanceEstimator.hpp
@@ -19,6 +19,7 @@ namespace services
             hal::Percent testVoltagePercent{ 15 };
             infra::Duration settleTime{ std::chrono::seconds{ 2 } };
             WindingConfiguration windingConfig{ WindingConfiguration::Wye };
+            infra::Duration noSampleTimeout{ std::chrono::milliseconds{ 100 } };
         };
 
         struct Result
@@ -50,5 +51,6 @@ namespace services
         infra::BoundedDeque<float>::WithMaxSize<averageFilterSize> currentSamples;
         infra::BoundedVector<float>::WithMaxSize<steadyStateSamplesSize> filteredSamples;
         infra::TimerSingleShot settleTimer;
+        infra::TimerSingleShot noSampleTimer;
     };
 }

--- a/core/services/electrical_system_ident/ResistanceEstimator.hpp
+++ b/core/services/electrical_system_ident/ResistanceEstimator.hpp
@@ -34,6 +34,9 @@ namespace services
         void Abort();
 
     private:
+        void StartSettlePhase();
+        void StartMeasurementPhase();
+        void OnMeasurementSample(foc::PhaseCurrents currents);
         void OnMeasurementComplete();
         void FailMeasurement();
 

--- a/core/services/electrical_system_ident/SinusoidalInductanceEstimator.cpp
+++ b/core/services/electrical_system_ident/SinusoidalInductanceEstimator.cpp
@@ -63,9 +63,20 @@ namespace services
 
         goertzel.emplace(config.measurementPeriods, measurementSamples);
 
+        // Bootstrap: write a zero-voltage vector so the PWM-triggered ADC fires and delivers
+        // the first sample to OnCurrentSample. Without this, the TI PWM module is stopped after
+        // resistance measurement and the callback never fires.
+        driver.ThreePhasePwmOutput(detail::NormalizedDutyCycles(
+            transforms.Inverse(foc::RotatingFrame{ 0.0f, 0.0f }, 1.0f, 0.0f)));
+
         driver.PhaseCurrentsReady(samplingFrequency, [this](auto currents)
             {
                 OnCurrentSample(currents);
+            });
+
+        noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
+            {
+                FailMeasurement();
             });
     }
 
@@ -74,8 +85,16 @@ namespace services
         if (!onDone)
             return;
 
+        noSampleTimer.Cancel();
         driver.Stop();
         onDone = nullptr;
+    }
+
+    void SinusoidalInductanceEstimator::FailMeasurement()
+    {
+        driver.Stop();
+        if (onDone)
+            onDone(Result{});
     }
 
     void SinusoidalInductanceEstimator::OnCurrentSample(foc::PhaseCurrents currents)
@@ -85,10 +104,16 @@ namespace services
 
         if (ExceedsInjectionLimit(currents, driver.MaxCurrentSupported()))
         {
+            noSampleTimer.Cancel();
             driver.Stop();
             onDone(Result{});
             return;
         }
+
+        noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
+            {
+                FailMeasurement();
+            });
 
         const float vNorm = injectionAmplitude * math::Sin(injectionPhase);
         driver.ThreePhasePwmOutput(detail::NormalizedDutyCycles(
@@ -109,6 +134,7 @@ namespace services
 
         if (goertzel->Ready())
         {
+            noSampleTimer.Cancel();
             driver.Stop();
             onDone(ComputeResult());
         }

--- a/core/services/electrical_system_ident/SinusoidalInductanceEstimator.cpp
+++ b/core/services/electrical_system_ident/SinusoidalInductanceEstimator.cpp
@@ -23,6 +23,13 @@ namespace services
         , vdc(vdc)
     {}
 
+    SinusoidalInductanceEstimator::~SinusoidalInductanceEstimator()
+    {
+        noSampleTimer.Cancel();
+        if (onDone)
+            driver.Stop();
+    }
+
     void SinusoidalInductanceEstimator::Start(const Config& config, const infra::Function<void(Result)>& onDone)
     {
         activeConfig = config;
@@ -30,7 +37,7 @@ namespace services
 
         if (!InitializeParameters())
         {
-            onDone(Result{});
+            this->onDone(Result{});
             return;
         }
 

--- a/core/services/electrical_system_ident/SinusoidalInductanceEstimator.cpp
+++ b/core/services/electrical_system_ident/SinusoidalInductanceEstimator.cpp
@@ -28,41 +28,45 @@ namespace services
         activeConfig = config;
         this->onDone = onDone;
 
-        const auto fs = static_cast<float>(samplingFrequency.Value());
-        const auto fInj = static_cast<float>(config.injectionFrequency.Value());
+        if (!InitializeParameters())
+        {
+            onDone(Result{});
+            return;
+        }
 
-        // Snap to an integer samples-per-period so the Goertzel bin and the injection are
-        // at the same frequency; any mismatch causes spectral leakage that biases Im(Z).
+        BeginInjection();
+    }
+
+    bool SinusoidalInductanceEstimator::InitializeParameters()
+    {
+        const auto fs = static_cast<float>(samplingFrequency.Value());
+        const auto fInj = static_cast<float>(activeConfig.injectionFrequency.Value());
         const auto samplesPerPeriod = fInj > 0.0f
                                           ? static_cast<std::size_t>(std::round(fs / fInj))
                                           : std::size_t{ 0 };
 
         if (samplesPerPeriod == 0)
-        {
-            onDone(Result{});
-            return;
-        }
+            return false;
+
         omega = twoPi * fs / static_cast<float>(samplesPerPeriod);
         phaseIncrement = omega / fs;
         injectionPhase = 0.0f;
-
-        // Clarke inverse of {v, 0} gives ThreePhase{v, -v/2, -v/2}; after NormalizedDutyCycles
-        // the terminal A-to-BC amplitude is v * 0.75 * Vdc.
-        injectionAmplitude = static_cast<float>(config.injectionVoltagePercent.Value()) / 100.0f;
+        injectionAmplitude = static_cast<float>(activeConfig.injectionVoltagePercent.Value()) / 100.0f;
         vTerminalAmplitude = injectionAmplitude * 0.75f * vdc.Value();
-
-        terminalFactor = config.windingConfig == WindingConfiguration::Delta
+        terminalFactor = activeConfig.windingConfig == WindingConfiguration::Delta
                              ? deltaTerminalFactor
                              : wyeTerminalFactor;
-
-        warmupSamples = config.warmupPeriods * samplesPerPeriod;
-        measurementSamples = config.measurementPeriods * samplesPerPeriod;
-
+        warmupSamples = activeConfig.warmupPeriods * samplesPerPeriod;
+        measurementSamples = activeConfig.measurementPeriods * samplesPerPeriod;
         sampleCount = 0;
         sumSquared = 0.0f;
+        goertzel.emplace(activeConfig.measurementPeriods, measurementSamples);
 
-        goertzel.emplace(config.measurementPeriods, measurementSamples);
+        return true;
+    }
 
+    void SinusoidalInductanceEstimator::BeginInjection()
+    {
         driver.PhaseCurrentsReady(samplingFrequency, [this](auto currents)
             {
                 OnCurrentSample(currents);
@@ -94,19 +98,8 @@ namespace services
             onDone(Result{});
     }
 
-    void SinusoidalInductanceEstimator::OnCurrentSample(foc::PhaseCurrents currents)
+    void SinusoidalInductanceEstimator::AdvanceInjection()
     {
-        if (!onDone)
-            return;
-
-        if (ExceedsInjectionLimit(currents, driver.MaxCurrentSupported()))
-        {
-            noSampleTimer.Cancel();
-            driver.Stop();
-            onDone(Result{});
-            return;
-        }
-
         noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
             {
                 FailMeasurement();
@@ -121,6 +114,22 @@ namespace services
             injectionPhase -= twoPi;
 
         ++sampleCount;
+    }
+
+    void SinusoidalInductanceEstimator::OnCurrentSample(foc::PhaseCurrents currents)
+    {
+        if (!onDone)
+            return;
+
+        if (ExceedsInjectionLimit(currents, driver.MaxCurrentSupported()))
+        {
+            noSampleTimer.Cancel();
+            driver.Stop();
+            onDone(Result{});
+            return;
+        }
+
+        AdvanceInjection();
 
         if (sampleCount <= warmupSamples)
             return;
@@ -141,7 +150,6 @@ namespace services
     {
         auto I = goertzel->Result();
 
-        // Rotate by +ω·d·Ts to cancel the d-sample ADC pipeline lag.
         const float delayAngle = omega * static_cast<float>(activeConfig.voltageToCurrentDelaySamples) / static_cast<float>(samplingFrequency.Value());
         const float cosD = math::Cos(delayAngle);
         const float sinD = math::Sin(delayAngle);

--- a/core/services/electrical_system_ident/SinusoidalInductanceEstimator.cpp
+++ b/core/services/electrical_system_ident/SinusoidalInductanceEstimator.cpp
@@ -63,16 +63,13 @@ namespace services
 
         goertzel.emplace(config.measurementPeriods, measurementSamples);
 
-        // Bootstrap: write a zero-voltage vector so the PWM-triggered ADC fires and delivers
-        // the first sample to OnCurrentSample. Without this, the TI PWM module is stopped after
-        // resistance measurement and the callback never fires.
-        driver.ThreePhasePwmOutput(detail::NormalizedDutyCycles(
-            transforms.Inverse(foc::RotatingFrame{ 0.0f, 0.0f }, 1.0f, 0.0f)));
-
         driver.PhaseCurrentsReady(samplingFrequency, [this](auto currents)
             {
                 OnCurrentSample(currents);
             });
+
+        driver.ThreePhasePwmOutput(detail::NormalizedDutyCycles(
+            transforms.Inverse(foc::RotatingFrame{ 0.0f, 0.0f }, 1.0f, 0.0f)));
 
         noSampleTimer.Start(activeConfig.noSampleTimeout, [this]()
             {

--- a/core/services/electrical_system_ident/SinusoidalInductanceEstimator.hpp
+++ b/core/services/electrical_system_ident/SinusoidalInductanceEstimator.hpp
@@ -38,6 +38,9 @@ namespace services
         void Abort();
 
     private:
+        bool InitializeParameters();
+        void BeginInjection();
+        void AdvanceInjection();
         void OnCurrentSample(foc::PhaseCurrents currents);
         void FailMeasurement();
         Result ComputeResult() const;

--- a/core/services/electrical_system_ident/SinusoidalInductanceEstimator.hpp
+++ b/core/services/electrical_system_ident/SinusoidalInductanceEstimator.hpp
@@ -4,6 +4,7 @@
 #include "core/foc/transforms/TransformsClarkePark.hpp"
 #include "core/platform_abstraction/interfaces/Drivers.hpp"
 #include "core/services/electrical_system_ident/ElectricalParametersIdentification.hpp"
+#include "infra/timer/Timer.hpp"
 #include "infra/util/AutoResetFunction.hpp"
 #include "numerical/analysis/GoertzelAlgorithm.hpp"
 #include <optional>
@@ -21,6 +22,7 @@ namespace services
             std::size_t measurementPeriods{ 20 };
             std::size_t voltageToCurrentDelaySamples{ 1 };
             WindingConfiguration windingConfig{ WindingConfiguration::Wye };
+            infra::Duration noSampleTimeout{ std::chrono::milliseconds{ 100 } };
         };
 
         struct Result
@@ -37,6 +39,7 @@ namespace services
 
     private:
         void OnCurrentSample(foc::PhaseCurrents currents);
+        void FailMeasurement();
         Result ComputeResult() const;
 
         static constexpr float wyeTerminalFactor = 1.5f;
@@ -48,6 +51,7 @@ namespace services
 
         Config activeConfig;
         infra::AutoResetFunction<void(Result)> onDone;
+        infra::TimerSingleShot noSampleTimer;
 
         float injectionPhase{ 0.0f };
         float phaseIncrement{ 0.0f };

--- a/core/services/electrical_system_ident/SinusoidalInductanceEstimator.hpp
+++ b/core/services/electrical_system_ident/SinusoidalInductanceEstimator.hpp
@@ -32,6 +32,7 @@ namespace services
         };
 
         SinusoidalInductanceEstimator(drivers::ThreePhaseInverter& driver, foc::Volts vdc);
+        ~SinusoidalInductanceEstimator();
 
         void Start(const Config& config, const infra::Function<void(Result)>& onDone);
 

--- a/core/services/electrical_system_ident/test/TestElectricalParametersIdentification.cpp
+++ b/core/services/electrical_system_ident/test/TestElectricalParametersIdentification.cpp
@@ -267,6 +267,7 @@ TEST_F(ElectricalParametersIdentificationTest, concurrent_rl_estimate_is_rejecte
 
     EXPECT_CALL(driverMock, PhaseCurrentsReady(::testing::_, ::testing::_));
     EXPECT_CALL(driverMock, ThreePhasePwmOutput(::testing::_));
+    EXPECT_CALL(driverMock, Stop());
 
     identification.EstimateResistanceAndInductance(config, [](services::ElectricalParametersIdentification::ResistanceInductanceResult) {});
 

--- a/core/services/electrical_system_ident/test/TestResistanceEstimator.cpp
+++ b/core/services/electrical_system_ident/test/TestResistanceEstimator.cpp
@@ -229,3 +229,55 @@ TEST_F(ResistanceEstimatorTest, recovers_resistance_for_low_resistance_motor)
     ASSERT_TRUE(result.resistance.has_value());
     EXPECT_NEAR(result.resistance->Value(), terminalR / 1.5f, 0.01f);
 }
+
+TEST_F(ResistanceEstimatorTest, no_sample_timeout_aborts_if_no_adc_callback_after_settle)
+{
+    services::ResistanceEstimator::Config config{
+        hal::Percent{ 15 }, std::chrono::milliseconds{ 50 }, services::WindingConfiguration::Wye,
+        std::chrono::milliseconds{ 100 }
+    };
+
+    std::optional<services::ResistanceEstimator::Result> result;
+
+    EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
+        .Times(2)
+        .WillRepeatedly([this](auto, const auto& cb) { driverMock.StorePhaseCurrentsCallback(cb); });
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_));
+    EXPECT_CALL(driverMock, Stop());
+
+    estimator.Start(config, [&result](auto r) { result = r; });
+    ForwardTime(config.settleTime);
+
+    ForwardTime(config.noSampleTimeout + std::chrono::milliseconds{ 1 });
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(result->resistance.has_value());
+}
+
+TEST_F(ResistanceEstimatorTest, no_sample_timeout_resets_per_sample_and_fires_when_samples_stop)
+{
+    services::ResistanceEstimator::Config config{
+        hal::Percent{ 15 }, std::chrono::milliseconds{ 50 }, services::WindingConfiguration::Wye,
+        std::chrono::milliseconds{ 100 }
+    };
+
+    std::optional<services::ResistanceEstimator::Result> result;
+
+    EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
+        .Times(2)
+        .WillRepeatedly([this](auto, const auto& cb) { driverMock.StorePhaseCurrentsCallback(cb); });
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_));
+    EXPECT_CALL(driverMock, Stop());
+
+    estimator.Start(config, [&result](auto r) { result = r; });
+    ForwardTime(config.settleTime);
+
+    for (std::size_t i = 0; i < 5; ++i)
+        driverMock.TriggerPhaseCurrentsCallback(foc::PhaseCurrents{
+            foc::Ampere{ 1.0f }, foc::Ampere{ 0.0f }, foc::Ampere{ 0.0f } });
+
+    ForwardTime(config.noSampleTimeout + std::chrono::milliseconds{ 1 });
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(result->resistance.has_value());
+}

--- a/core/services/electrical_system_ident/test/TestResistanceEstimator.cpp
+++ b/core/services/electrical_system_ident/test/TestResistanceEstimator.cpp
@@ -35,6 +35,7 @@ TEST_F(ResistanceEstimatorTest, start_applies_test_voltage_and_registers_blank_c
     EXPECT_CALL(driverMock, PhaseCurrentsReady(hal::Hertz{ 10000 }, _));
     EXPECT_CALL(driverMock, ThreePhasePwmOutput(PhasePwmDutyCyclesEq(foc::PhasePwmDutyCycles{
                                 hal::Percent{ 15 }, hal::Percent{ 1 }, hal::Percent{ 1 } })));
+    EXPECT_CALL(driverMock, Stop());
 
     estimator.Start(config, [](auto) {});
 }
@@ -42,7 +43,8 @@ TEST_F(ResistanceEstimatorTest, start_applies_test_voltage_and_registers_blank_c
 TEST_F(ResistanceEstimatorTest, registers_sampling_callback_after_settle_time)
 {
     services::ResistanceEstimator::Config config{
-        hal::Percent{ 20 }, std::chrono::milliseconds{ 100 }, services::WindingConfiguration::Wye
+        hal::Percent{ 20 }, std::chrono::milliseconds{ 100 }, services::WindingConfiguration::Wye,
+        std::chrono::seconds{ 1 }
     };
 
     EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
@@ -53,6 +55,7 @@ TEST_F(ResistanceEstimatorTest, registers_sampling_callback_after_settle_time)
             });
     EXPECT_CALL(driverMock, ThreePhasePwmOutput(PhasePwmDutyCyclesEq(foc::PhasePwmDutyCycles{
                                 hal::Percent{ 20 }, hal::Percent{ 1 }, hal::Percent{ 1 } })));
+    EXPECT_CALL(driverMock, Stop());
 
     estimator.Start(config, [](auto) {});
     ForwardTime(std::chrono::milliseconds{ 100 });
@@ -280,4 +283,43 @@ TEST_F(ResistanceEstimatorTest, no_sample_timeout_resets_per_sample_and_fires_wh
 
     ASSERT_TRUE(result.has_value());
     EXPECT_FALSE(result->resistance.has_value());
+}
+
+TEST_F(ResistanceEstimatorTest, no_sample_timeout_fires_during_settle_if_no_adc_callback)
+{
+    services::ResistanceEstimator::Config config{
+        hal::Percent{ 15 }, std::chrono::seconds{ 2 }, services::WindingConfiguration::Wye,
+        std::chrono::milliseconds{ 100 }
+    };
+
+    std::optional<services::ResistanceEstimator::Result> result;
+
+    EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
+        .WillOnce([this](auto, const auto& cb) { driverMock.StorePhaseCurrentsCallback(cb); });
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_));
+    EXPECT_CALL(driverMock, Stop());
+
+    estimator.Start(config, [&result](auto r) { result = r; });
+
+    ForwardTime(config.noSampleTimeout + std::chrono::milliseconds{ 1 });
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(result->resistance.has_value());
+}
+
+TEST_F(ResistanceEstimatorTest, destructor_stops_driver_when_destroyed_while_active)
+{
+    services::ResistanceEstimator::Config config{
+        hal::Percent{ 15 }, std::chrono::seconds{ 2 }, services::WindingConfiguration::Wye,
+        std::chrono::seconds{ 5 }
+    };
+
+    EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _));
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_));
+    EXPECT_CALL(driverMock, Stop());
+
+    {
+        services::ResistanceEstimator local{ driverMock, foc::Volts{ 24.0f } };
+        local.Start(config, [](auto) {});
+    }
 }

--- a/core/services/electrical_system_ident/test/TestSinusoidalInductanceEstimator.cpp
+++ b/core/services/electrical_system_ident/test/TestSinusoidalInductanceEstimator.cpp
@@ -1,6 +1,7 @@
 #include "core/foc/current_loop/CurrentPlantModel.hpp"
 #include "core/platform_abstraction/interfaces/test_doubles/DriversMock.hpp"
 #include "core/services/electrical_system_ident/SinusoidalInductanceEstimator.hpp"
+#include "infra/timer/test_helper/ClockFixture.hpp"
 #include <cmath>
 #include <gmock/gmock.h>
 #include <numbers>
@@ -62,7 +63,7 @@ namespace
                 {
                     driverMock.StorePhaseCurrentsCallback(cb);
                 });
-        EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(totalSamples);
+        EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(totalSamples + 1);
         EXPECT_CALL(driverMock, Stop());
 
         estimator.Start(config, [&result](auto r) { result = r; });
@@ -86,7 +87,9 @@ namespace
         return { result, expectedL };
     }
 
-    class SinusoidalInductanceEstimatorTest : public ::testing::Test
+    class SinusoidalInductanceEstimatorTest
+        : public ::testing::Test
+        , public infra::ClockFixture
     {
     public:
         StrictMock<drivers::ThreePhaseInverterMock> driverMock;
@@ -99,6 +102,7 @@ TEST_F(SinusoidalInductanceEstimatorTest, start_registers_phase_current_callback
 {
     services::SinusoidalInductanceEstimator::Config config{};
 
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(1);
     EXPECT_CALL(driverMock, PhaseCurrentsReady(hal::Hertz{ 10000 }, _));
 
     estimator.Start(config, [](auto) {});
@@ -118,7 +122,7 @@ TEST_F(SinusoidalInductanceEstimatorTest, zero_current_response_returns_no_induc
 
     EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
         .WillOnce([this](auto, const auto& cb) { driverMock.StorePhaseCurrentsCallback(cb); });
-    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(totalSamples);
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(totalSamples + 1);
     EXPECT_CALL(driverMock, Stop());
 
     estimator.Start(config, [&result](auto r) { result = r; });
@@ -195,7 +199,7 @@ TEST_F(SinusoidalInductanceEstimatorTest, fitQuality_drops_for_unexpected_signal
 
     EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
         .WillOnce([this](auto, const auto& cb) { driverMock.StorePhaseCurrentsCallback(cb); });
-    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(totalSamples);
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(totalSamples + 1);
     EXPECT_CALL(driverMock, Stop());
 
     estimator.Start(config, [&result](auto r) { result = r; });
@@ -238,7 +242,7 @@ TEST_F(SinusoidalInductanceEstimatorTest, negative_zimag_returns_nullopt_inducta
 
     EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
         .WillOnce([this](auto, const auto& cb) { driverMock.StorePhaseCurrentsCallback(cb); });
-    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(totalSamples);
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(totalSamples + 1);
     EXPECT_CALL(driverMock, Stop());
 
     estimator.Start(config, [&result](auto r) { result = r; });
@@ -270,6 +274,7 @@ TEST_F(SinusoidalInductanceEstimatorTest, overcurrent_on_first_sample_stops_driv
 
     EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
         .WillOnce([this](auto, const auto& cb) { driverMock.StorePhaseCurrentsCallback(cb); });
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(1);
     EXPECT_CALL(driverMock, Stop());
 
     estimator.Start(config, [&result](auto r) { result = r; });
@@ -293,6 +298,7 @@ TEST_F(SinusoidalInductanceEstimatorTest, overcurrent_on_phase_b_also_aborts)
 
     EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
         .WillOnce([this](auto, const auto& cb) { driverMock.StorePhaseCurrentsCallback(cb); });
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(1);
     EXPECT_CALL(driverMock, Stop());
 
     estimator.Start(config, [&result](auto r) { result = r; });
@@ -323,4 +329,48 @@ TEST_F(SinusoidalInductanceEstimatorTest, delta_winding_recovers_inductance_corr
 
     ASSERT_TRUE(result.inductance.has_value());
     EXPECT_NEAR(result.inductance->Value(), expectedL, expectedL * 0.02f);
+}
+
+TEST_F(SinusoidalInductanceEstimatorTest, no_sample_timeout_fires_if_no_adc_callback_arrives)
+{
+    services::SinusoidalInductanceEstimator::Config config{};
+    services::SinusoidalInductanceEstimator::Result result{ foc::MilliHenry{ 99.0f }, 1.0f };
+
+    EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
+        .WillOnce([this](auto, const auto& cb) { driverMock.StorePhaseCurrentsCallback(cb); });
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(1);
+    EXPECT_CALL(driverMock, Stop());
+
+    estimator.Start(config, [&result](auto r) { result = r; });
+
+    ForwardTime(config.noSampleTimeout + std::chrono::milliseconds{ 1 });
+
+    EXPECT_FALSE(result.inductance.has_value());
+    EXPECT_FLOAT_EQ(result.fitQuality, 0.0f);
+}
+
+TEST_F(SinusoidalInductanceEstimatorTest, no_sample_timeout_resets_per_sample_and_fires_when_samples_stop)
+{
+    services::SinusoidalInductanceEstimator::Config config{
+        hal::Hertz{ 700 }, hal::Percent{ 15 }, 2, 5, 1, services::WindingConfiguration::Wye
+    };
+
+    constexpr std::size_t samplesSent = 3;
+    services::SinusoidalInductanceEstimator::Result result{ foc::MilliHenry{ 99.0f }, 1.0f };
+
+    EXPECT_CALL(driverMock, PhaseCurrentsReady(_, _))
+        .WillOnce([this](auto, const auto& cb) { driverMock.StorePhaseCurrentsCallback(cb); });
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(samplesSent + 1);
+    EXPECT_CALL(driverMock, Stop());
+
+    estimator.Start(config, [&result](auto r) { result = r; });
+
+    for (std::size_t k = 0; k < samplesSent; ++k)
+        driverMock.TriggerPhaseCurrentsCallback(foc::PhaseCurrents{
+            foc::Ampere{ 0.0f }, foc::Ampere{ 0.0f }, foc::Ampere{ 0.0f } });
+
+    ForwardTime(config.noSampleTimeout + std::chrono::milliseconds{ 1 });
+
+    EXPECT_FALSE(result.inductance.has_value());
+    EXPECT_FLOAT_EQ(result.fitQuality, 0.0f);
 }

--- a/core/services/electrical_system_ident/test/TestSinusoidalInductanceEstimator.cpp
+++ b/core/services/electrical_system_ident/test/TestSinusoidalInductanceEstimator.cpp
@@ -102,8 +102,9 @@ TEST_F(SinusoidalInductanceEstimatorTest, start_registers_phase_current_callback
 {
     services::SinusoidalInductanceEstimator::Config config{};
 
-    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(1);
     EXPECT_CALL(driverMock, PhaseCurrentsReady(hal::Hertz{ 10000 }, _));
+    EXPECT_CALL(driverMock, ThreePhasePwmOutput(_)).Times(1);
+    EXPECT_CALL(driverMock, Stop());
 
     estimator.Start(config, [](auto) {});
 }
@@ -373,4 +374,19 @@ TEST_F(SinusoidalInductanceEstimatorTest, no_sample_timeout_resets_per_sample_an
 
     EXPECT_FALSE(result.inductance.has_value());
     EXPECT_FLOAT_EQ(result.fitQuality, 0.0f);
+}
+
+TEST_F(SinusoidalInductanceEstimatorTest, destructor_stops_driver_when_destroyed_while_active)
+{
+    services::SinusoidalInductanceEstimator::Config config{};
+
+    StrictMock<drivers::ThreePhaseInverterMock> localMock;
+    EXPECT_CALL(localMock, PhaseCurrentsReady(_, _));
+    EXPECT_CALL(localMock, ThreePhasePwmOutput(_)).Times(1);
+    EXPECT_CALL(localMock, Stop());
+
+    {
+        services::SinusoidalInductanceEstimator local{ localMock, foc::Volts{ 24.0f } };
+        local.Start(config, [](auto) {});
+    }
 }

--- a/documentation/design/service-electrical-ident.md
+++ b/documentation/design/service-electrical-ident.md
@@ -90,10 +90,14 @@ pending completion, and a sample that arrives after the procedure ended is disca
 anything. This matters most for the inductance injection, whose callback writes duty cycles on every sample:
 ungated, it would re-arm the peripheral that the abort had just stopped.
 
-`Abort()` is the caller-facing form of the same shutdown. It stops injection, cancels the timers, and drops
-the pending completion **without invoking it** — the caller that aborted owns the outcome, so a fault raised
-by the state machine cannot be overwritten by the result of the procedure it interrupted. It covers whichever
-stage is live: resistance, inductance injection, or the pole-pairs sweep.
+`Abort()` is the caller-facing form of the same shutdown. It stops injection, cancels all timers (including
+the no-sample watchdog), and drops the pending completion **without invoking it** — the caller that aborted
+owns the outcome, so a fault raised by the state machine cannot be overwritten by the result of the
+procedure it interrupted. It covers whichever stage is live: resistance, inductance injection, or the
+pole-pairs sweep.
+
+Every estimator is also RAII-safe: if destroyed while active, the destructor cancels all timers and stops
+the driver without invoking the completion callback.
 
 ### ResistanceEstimator
 
@@ -106,13 +110,26 @@ When the buffer is full, the steady-state current is read from the mean of the l
 buffer. Resistance is computed as $V_{step} / I_{ss}$ divided by the winding topology factor. If
 $I_{ss} \leq 0$, the result is absent.
 
+**No-sample watchdog:** a second `TimerSingleShot` is armed immediately after the DC duty is applied
+and resets on every ADC callback (during both settle and measurement phases). Default bound: 100 ms
+(`Config::noSampleTimeout`). If the ADC produces no callback within that window — whether at startup
+or after samples stop mid-measurement — the watchdog fires `FailMeasurement()`, stopping the driver
+and delivering an absent result. This ensures ADC loss does not leave the motor energised
+indefinitely regardless of the configured settle time.
+
+**RAII cleanup:** the destructor cancels all timers and stops the driver if the estimator is
+destroyed while a measurement is active, so callers do not need to call `Abort()` explicitly before
+releasing the object.
+
 ```mermaid
 stateDiagram-v2
     [*] --> Idle
     Idle --> Settling : Start(config, onDone)
     Settling --> Measuring : settle timer fires
+    Settling --> Fault : no-sample watchdog fires (no ADC in 100 ms)
     Measuring --> Done : buffer full, I_ss > 0
     Measuring --> Fault : I_ss ≤ 0
+    Measuring --> Fault : no-sample watchdog fires
     Done --> Idle : onDone({resistance}) fired
     Fault --> Idle : onDone({nullopt}) fired
 ```
@@ -156,18 +173,32 @@ zero with increasing noise or rotor motion.
 | sumSquared     | 1 float | Accumulates $\Sigma i^2$ for fitQuality |
 | sampleCount    | 1 int   | Warmup/measurement gate                 |
 
+**PWM bootstrap:** the ADC on TI targets is triggered by the PWM peripheral. Because the resistance
+estimator stops PWM on completion, the inductance estimator writes a zero-voltage vector immediately
+after registering the ADC callback to restart the PWM-triggered ADC chain before the first sample
+is expected.
+
+**No-sample watchdog:** a `TimerSingleShot` is armed when injection begins and resets on every ADC
+callback. Default bound: 100 ms (`Config::noSampleTimeout`). Loss of ADC samples — whether the
+bootstrap never triggers or samples stop mid-measurement — causes the watchdog to fire
+`FailMeasurement()`, stopping the driver and delivering an absent result within the documented bound.
+
+**RAII cleanup:** the destructor cancels the watchdog timer and stops the driver if the estimator is
+destroyed while a measurement is active.
+
 ```mermaid
 stateDiagram-v2
     [*] --> Idle
-    Idle --> Warmup : Start(config, onDone)
+    Idle --> Warmup : Start(config, onDone)\nPWM bootstrap written
     Warmup --> Measuring : warmupPeriods complete
-    Warmup --> Abort : phase current exceeds MaxCurrentSupported()
+    Warmup --> Fault : phase current exceeds MaxCurrentSupported()
+    Warmup --> Fault : no-sample watchdog fires (no ADC in 100 ms)
     Measuring --> Done : Goertzel ready, L > 0
     Measuring --> Fault : L ≤ 0 or noise floor
-    Measuring --> Abort : phase current exceeds MaxCurrentSupported()
+    Measuring --> Fault : phase current exceeds MaxCurrentSupported()
+    Measuring --> Fault : no-sample watchdog fires
     Done --> Idle : onDone({inductance, fitQuality}) fired
-    Fault --> Idle : onDone({nullopt, fitQuality}) fired
-    Abort --> Idle : driver.Stop(), onDone({nullopt, 0}) fired
+    Fault --> Idle : driver.Stop(), onDone({nullopt, 0}) fired
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes #269

- **PWM bootstrap in `SinusoidalInductanceEstimator`**: After `ResistanceEstimator` calls `driver.Stop()`, the TI PWM module is disabled. The inductance stage registered an ADC callback but never wrote a PWM vector, so the PWM-triggered ADC never fired and the stage hung indefinitely. A zero-voltage bootstrap write is now issued before `PhaseCurrentsReady` to restart the PWM-triggered ADC chain.
- **Per-sample no-sample watchdog in both estimators**: A `TimerSingleShot` (default 100 ms) is armed at the start of each sampling phase and reset on every ADC callback. If no sample arrives within the window — whether due to ADC failure at startup or mid-measurement — the timer fires `FailMeasurement()`, which stops the driver and returns an empty result. All completion paths (success, overcurrent, timeout, `Abort`) cancel the timer and stop PWM.

## Test plan

- [ ] All 49 existing unit tests still pass (`ctest --preset host`)
- [ ] `no_sample_timeout_fires_if_no_adc_callback_arrives` — verifies bootstrap + initial timeout
- [ ] `no_sample_timeout_resets_per_sample_and_fires_when_samples_stop` — verifies mid-measurement loss detection (both estimators)
- [ ] `no_sample_timeout_aborts_if_no_adc_callback_after_settle` — verifies resistance estimator measurement-phase timeout
- [ ] TI HIL: full R/L identification sequence progresses from resistance to inductance without manually injected callbacks (acceptance criterion #1)
- [ ] Fault-injection HIL: suppressing ADC completion while duty is active stops injection within 100 ms (acceptance criterion #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)